### PR TITLE
Mitigate Wine _stricmp issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ LDFLAGS := \
 OBJS := \
 	obj/dll/rugburn/main.o \
 	obj/hooks/kernel32/inject.o \
+	obj/hooks/msvcr100/msvcr100.o \
 	obj/hooks/user32/window.o \
 	obj/hooks/ws2_32/redir.o \
 	obj/hooks/wininet/netredir.o \

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677807368,
-        "narHash": "sha256-ELolIz8Ja+JAhq5UFlgGdkppMuJJFU4buMW4KlxYpG0=",
+        "lastModified": 1684621518,
+        "narHash": "sha256-iumviKNdVwoR/hkM/BzBdXSr7Oxe0TnoqXfIdaeX6XQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a63cf30f83c1284008eaea61e226986b817b128",
+        "rev": "22674f899fe1217785280e9df31c0123b8916210",
         "type": "github"
       },
       "original": {
@@ -34,6 +37,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/src/hooks/hooks.c
+++ b/src/hooks/hooks.c
@@ -1,12 +1,14 @@
 #include "hooks.h"
 
 #include "kernel32/inject.h"
+#include "msvcr100/msvcr100.h"
 #include "user32/window.h"
 #include "wininet/netredir.h"
 #include "ws2_32/redir.h"
 
 VOID InitHooks() {
     InitInjectHook();
+    InitMsvcr100Hook();
     InitWindowHook();
     InitNetRedirHook();
     InitRedirHook();

--- a/src/hooks/msvcr100/msvcr100.c
+++ b/src/hooks/msvcr100/msvcr100.c
@@ -1,0 +1,56 @@
+#include "msvcr100.h"
+#include "../../patch.h"
+
+typedef int (__cdecl* STRICMPFNPTR)(const char *s1, const char *s2);
+typedef char *(__cdecl* SETLOCALEFNPTR)(int category, const char *locale);
+
+static HMODULE hMsvcr100Module = NULL;
+static STRICMPFNPTR pStricmp = NULL;
+static SETLOCALEFNPTR pSetLocale = NULL;
+
+int lower(int c) {
+    return (c >= 'A' && c <= 'Z') ? c + 'a' - 'A' : c;
+}
+
+int __cdecl StricmpHook(const char *s1, const char *s2) {
+    int result = 0;
+    if (!s1 || !s2) return 0x7fffffff;
+    while (!result) {
+        result = lower(*s1) - lower(*s2);
+        if (!*s1 || !*s2) break;
+        s1++, s2++;
+    }
+    return result;
+}
+
+VOID InitMsvcr100Hook() {
+    const char *oldlocale;
+    int result;
+
+    hMsvcr100Module = LoadLib("msvcr100");
+    if (!hMsvcr100Module) {
+        Log("Not checking for Wine _stricmp bug: msvcr100 not found.\n");
+        return;
+    }
+
+    pStricmp = GetProc(hMsvcr100Module, "_stricmp");
+    pSetLocale = GetProc(hMsvcr100Module, "setlocale");
+    oldlocale = pSetLocale(2, NULL);
+    if (!pStricmp || !pSetLocale) {
+        Log("Not checking for Wine _stricmp bug: msvcr100 functions not found.\n");
+    }
+
+    Log("Checking for Wine _stricmp bug; current locale: %s - Temporarily switching to Kor.\n", oldlocale);
+
+    pSetLocale(2, "Kor");
+    result = pStricmp("\xB3\xA1", "\xBC\xBC");
+    pSetLocale(2, oldlocale);
+
+    if (result == 0) {
+        Log("Wine _stricmp bug detected; mitigating.\n");
+        pStricmp = HookProc(hMsvcr100Module, "_stricmp", StricmpHook);
+    } else {
+        Log("Wine _stricmp bug not detected.\n");
+    }
+}
+

--- a/src/hooks/msvcr100/msvcr100.h
+++ b/src/hooks/msvcr100/msvcr100.h
@@ -1,0 +1,8 @@
+#ifndef HOOKS_MSVCR100_MSVCR100_H
+#define HOOKS_MSVCR100_MSVCR100_H
+
+#include "../../common.h"
+
+VOID InitMsvcr100Hook();
+
+#endif


### PR DESCRIPTION
TODO: Need to report this issue upstream, should probably make some kind of winetest for it. TBD. :)

Fixes some issues when running PangYa under Wine. The Wine implementation of msvcr100 has issues with `stricmp` when using a multibyte locale, namely, case folding seems to cause partial multibyte segments to be treated inaccurately to original Visual C runtime.