### PR TITLE
Patch ProjectG USA 852.00

### DIFF
--- a/rugburn.vcxproj
+++ b/rugburn.vcxproj
@@ -190,6 +190,8 @@
     <ClCompile Include="src\patch.c" />
     <ClCompile Include="src\regex.c" />
     <ClCompile Include="src\third_party\lend\ld32.c" />
+    <ClCompile Include="src\hooks\msvcr100\msvcr100.c" />
+    <ClCompile Include="src\patch_usa_852.c" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\bootstrap.h" />
@@ -207,6 +209,8 @@
     <ClInclude Include="src\patch.h" />
     <ClInclude Include="src\regex.h" />
     <ClInclude Include="src\third_party\lend\ld32.h" />
+    <ClCompile Include="src\hooks\msvcr100\msvcr100.h" />
+    <ClCompile Include="src\patch_usa_852.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="exportvs.def" />

--- a/rugburn.vcxproj.filters
+++ b/rugburn.vcxproj.filters
@@ -15,6 +15,8 @@
     <ClCompile Include="src\json.c" />
     <ClCompile Include="src\regex.c" />
     <ClCompile Include="src\config.c" />
+    <ClCompile Include="src\hooks\msvcr100\msvcr100.c" />
+    <ClCompile Include="src\patch_usa_852.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\bootstrap.h" />
@@ -32,6 +34,8 @@
     <ClInclude Include="src\json.h" />
     <ClInclude Include="src\regex.h" />
     <ClInclude Include="src\config.h" />
+    <ClCompile Include="src\hooks\msvcr100\msvcr100.h" />
+    <ClCompile Include="src\patch_usa_852.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="exportvs.def" />

--- a/src/dll/rugburn/main.c
+++ b/src/dll/rugburn/main.c
@@ -17,6 +17,7 @@
 #include "../../ijlfwd.h"
 #include "../../patch.h"
 #include "../../hooks/hooks.h"
+#include "../../patch_usa_852.h"
 
 /**
  * InitEnvironment configures the PANGYA_ARG environment to avoid needing to
@@ -53,6 +54,34 @@ static VOID STDCALL PatchGG_US852(PVOID unused) {
             Patch((LPVOID)0x00A496E0, "\xC3", 1);
             Patch((LPVOID)0x00A49840, "\xC3", 1);
             Log("Patched GG check routines (US 852)\r\n");
+
+            Patch((LPVOID)0x00A6ECC9, "\x30\xC0", 2);
+			Log("Patched Cookie Point Item (US 852)\r\n");
+
+			Patch((LPVOID)0x005FB990, "\x80\xB9\x40\x02\x00\x00\x00\x0F\x85\x0D\x00\x00\x00\x8B\x89\x8C\x01\x00\x00\x8B\x01\x8B\x50\x4C\xFF\xD2\xC2\x04\x00", 29);
+			Log("Patched Cookie Btn in onCallback that's disabled (US 852)\r\n");
+
+			Patch((LPVOID)0x005FB9AD, "\xB3\x01\x31\xFF\x90\x53\xBA\xB4\x6A\xCE\x00\xE9\xC9\x31\x00\x00", 16);
+			Patch((LPVOID)0x005FEB7E, "\xE9\x2A\xCE\xFF\xFF", 5);
+			Patch((LPVOID)0x005FEB8D, "\x53", 1);
+			Patch((LPVOID)0x005FEB9A, "\x53", 1);
+			Patch((LPVOID)0x005FB9BD, "\x6A\x01\xBA\xB4\x6A\xCE\x00\x8B\xCE\xE8\xF5\x2C\x00\x00\x6A\x01\xBA\xB0\x69\xCE\x00\xE9\x29\x32\x00\x00", 26);
+			Patch((LPVOID)0x005FEBF9, "\xE9\xBF\xCD\xFF\xFF", 5);
+			Log("Patched Btn Cookie, Gacha and Scratch disabled (US 852)\r\n");
+
+			Patch((LPVOID)0x008BC729, "\x01", 1);
+			Patch((LPVOID)0x008C1495, "\xEB\x0C", 2);
+			Patch((LPVOID)0x008C14A3, "\xE8\xF8\xB2\xFF\xFF\x88\x86\xE4\x00\x00\x00\x5E\xC3", 13);
+			Log("Patched Btn Change Nickname disabled (US 852)\r\n");
+
+			unsigned char jmp_to_patch_ranking[5] = { 0xE9u, 0u, 0u, 0u, 0u };
+
+			DWORD relAddr = (DWORD)OnUnderBar_RankingUp - 0x00655630u - 5u;
+
+			memcpy(&jmp_to_patch_ranking[1], &relAddr, 4u);
+
+			Patch((LPVOID)0x00655630, jmp_to_patch_ranking, sizeof(jmp_to_patch_ranking));
+			Log("Patched Ranking System disabled (US 852)\r\n");
             return;
         }
         if (*(DWORD*)0x00A49580 == 0x8F143D83) {

--- a/src/patch_usa_852.c
+++ b/src/patch_usa_852.c
@@ -126,15 +126,15 @@ void __thiscall OnUnderBar_RankingUp(void* _this) {
 		CALLTHISFUNCTION(pDestructorWSendPacket, (void*)WSendPacketObject);
 	}
 
-	void* FormWndObject = *GETTHISPOINTERMEMBER(void*, 0x160u, _this);
+	void** FormWndObject = GETTHISPOINTERMEMBER(void*, 0x160u, _this);
 
-	if (FormWndObject == NULL) {
+	if (*FormWndObject == NULL) {
 
-		FormWndObject = CreateFormFrLoginRsDlg(*GETTHISPOINTERMEMBER(void*, 0x40u, gFresh), (void*)GETTHISPOINTERMEMBER(void*, 0x18, _this), "login_gs", NULL);
+		*FormWndObject = CreateFormFrLoginRsDlg(*GETTHISPOINTERMEMBER(void*, 0x40u, gFresh), (void*)GETTHISPOINTERMEMBER(void*, 0x18, _this), "login_gs", NULL);
 
 		pSetState(1u);
 
-		CALLTHISVIRTUALCALL(PFNFRFORMOPENPROC, 0x64u, FormWndObject, OnLoginRsDlgResult, 0xFFFFFFE8u, 0, 0, 0x41);
+		CALLTHISVIRTUALCALL(PFNFRFORMOPENPROC, 0x64u, *FormWndObject, OnLoginRsDlgResult, 0xFFFFFFE8u, 0, 0, 0x41);
 	}
 
 	CALLTHISFUNCTION(pClearToolTip, _this, NULL);

--- a/src/patch_usa_852.c
+++ b/src/patch_usa_852.c
@@ -1,0 +1,143 @@
+#include "patch_usa_852.h"
+
+typedef struct _stMsgObject {
+	void* m_pIActor;
+	uint32_t m_id;
+	uint32_t m_com[5];
+	uint32_t m_time;
+} stMsgObject;
+
+inline stMsgObject MakeMsgObject(void* _pIActor, uint32_t _id, uint32_t _c0, uint32_t _c1, uint32_t _c2, uint32_t _c3, uint32_t _c4) {
+	return (stMsgObject) { _pIActor, _id, _c0, _c1, _c2, _c3, _c4, 0u };
+}
+
+#define MAKEPROTOTYPETHISFUNCTION(_return_, _fnPrototype_, _type_this_, ...) typedef _return_ (__thiscall *_fnPrototype_)(_type_this_, uint32_t/*register EDX*/, __VA_ARGS__)
+#define CALLTHISFUNCTION(_func_, _this_, ...) _func_(_this_, 0u/*register EDX*/, __VA_ARGS__)
+
+#define MAKEVIRTUALCALL(_fnPrototype_, _addr_, _this_) (*(_fnPrototype_*)(*((uint8_t**)(_this_)) + (_addr_)))
+#define CALLTHISVIRTUALCALL(_fnPrototype_, _addr_, _this_, ...) CALLTHISFUNCTION(MAKEVIRTUALCALL(_fnPrototype_, _addr_, _this_), _this_, __VA_ARGS__)
+
+#define GETTHISPOINTERMEMBER(_type_, _addr_, _this_) (_type_*)(((uint8_t*)(_this_)) + (_addr_))
+
+typedef void* (__cdecl *PFNMAKEINSTANCEFRLOGINRSDLG)(void);
+typedef const char* (__fastcall *PFNBRASILTRANSLATESTRINGPROC)(const char* _str);
+typedef void(__fastcall *PFNFRLOGINRSDLGSETSTATEPROC)(uint32_t _state);
+
+MAKEPROTOTYPETHISFUNCTION(void*, PFNFRFORM_INITPROC, void*, void*, void*, const char*, void*);
+MAKEPROTOTYPETHISFUNCTION(void*, PFNIOBJECTDYNAMICCASTPROC, void*, const void*);
+MAKEPROTOTYPETHISFUNCTION(void*, PFNFRFORMLOGINRSDLGSCALARDELETINGDESTRUCTORPROC, void*, uint32_t);
+
+MAKEPROTOTYPETHISFUNCTION(uint64_t, PFNCSHAREDDOCISCONTROLSERVERSERVICEPROC, void*, uint64_t);
+MAKEPROTOTYPETHISFUNCTION(void, PFNVIRTUALIACTORHANDLEMSGPROC, void*, stMsgObject*);
+MAKEPROTOTYPETHISFUNCTION(void, PFNVIRTUALIACTORCLOSEALLDIALOGSPROC, void*);
+MAKEPROTOTYPETHISFUNCTION(BOOL, PFNWNETWORKSYSTEMISCONNECTEDPROC, void*, uint32_t);
+MAKEPROTOTYPETHISFUNCTION(BOOL, PFNWNETWORKSYSTEMINITPROC, void*, uint32_t);
+MAKEPROTOTYPETHISFUNCTION(BOOL, PFNWNETWORKSYSTEMSENDMESSAGEAPROC, void*, uint32_t, uint32_t);
+MAKEPROTOTYPETHISFUNCTION(void, PFNCONSTRUCTORWSENDPACKETPROC, void*, uint32_t);
+MAKEPROTOTYPETHISFUNCTION(void, PFNDESTRUCTORWSENDPACKETPROC, void*);
+MAKEPROTOTYPETHISFUNCTION(void, PFNWSENDPACKETSENDPROC, void*, uint32_t);
+MAKEPROTOTYPETHISFUNCTION(void, PFNCLOBBYMAINCLEARTOOLTIPPROC, void*, void*);
+MAKEPROTOTYPETHISFUNCTION(BOOL, PFNFRLOGINRSDLGONLOGINRSDLGRESULTPROC, void*, int32_t, void*);
+MAKEPROTOTYPETHISFUNCTION(BOOL, PFNFRFORMOPENPROC, void*, PFNFRLOGINRSDLGONLOGINRSDLGRESULTPROC, uint32_t, uint32_t, uint32_t, uint32_t);
+
+void* CreateFormFrLoginRsDlg(void* _pFrWndManager, void* _pFrCmdTarget, const char* _name, void* _pFrWnd) {
+
+	static void* g_pFrLoginRsDlgObject = NULL;
+
+	PFNMAKEINSTANCEFRLOGINRSDLG pMakeInstanceFrLoginRsDlg = (PFNMAKEINSTANCEFRLOGINRSDLG)0x00AC4680u;
+	PFNFRFORM_INITPROC p_Init = (PFNFRFORM_INITPROC)0x00BCDD40u;
+	PFNIOBJECTDYNAMICCASTPROC pDynamicCast = (PFNIOBJECTDYNAMICCASTPROC)0x0047EFF0u;
+
+	const void* pFrLoginRsDlg_m_RTTI = (const void*)0x00ECA148u;
+
+	void* pFrLoginRsDlgObject = pMakeInstanceFrLoginRsDlg();
+
+	if (pFrLoginRsDlgObject == NULL)
+		return NULL;
+
+	void* pFrLoginRsDlgObjectAfter = CALLTHISFUNCTION(p_Init, pFrLoginRsDlgObject, _pFrWndManager, _pFrCmdTarget, _name, _pFrWnd);
+
+	if (pFrLoginRsDlgObjectAfter != NULL) {
+
+		// Test to see if it saves the value in tls as it is in pangya
+		g_pFrLoginRsDlgObject = pFrLoginRsDlgObjectAfter;
+
+		return CALLTHISFUNCTION(pDynamicCast, pFrLoginRsDlgObjectAfter, pFrLoginRsDlg_m_RTTI);
+	}
+
+	if (pFrLoginRsDlgObject != NULL)
+		CALLTHISVIRTUALCALL(PFNFRFORMLOGINRSDLGSCALARDELETINGDESTRUCTORPROC, 0x04u, pFrLoginRsDlgObject, 1u);
+
+	return NULL;
+}
+
+BOOL __thiscall OnLoginRsDlgResult(void* _this, uint32_t _EDX, int32_t exit_code/*I think*/, void* _pFrForm) {
+	(_EDX); // UNREFERENCED_PARAMETER
+
+	if (_this != NULL)
+		*GETTHISPOINTERMEMBER(void*, 0x160u, _this) = NULL;
+
+	return TRUE;
+}
+
+void __thiscall OnUnderBar_RankingUp(void* _this) {
+
+	PFNCSHAREDDOCISCONTROLSERVERSERVICEPROC pIsControlServerService = (PFNCSHAREDDOCISCONTROLSERVERSERVICEPROC)0x0062E4A0;
+	PFNBRASILTRANSLATESTRINGPROC pBrasilTranslateString = (PFNBRASILTRANSLATESTRINGPROC)0x00B3A7E0u;
+	PFNWNETWORKSYSTEMISCONNECTEDPROC pIsConnected = (PFNWNETWORKSYSTEMISCONNECTEDPROC)0x00A3AEB0u;
+	PFNWNETWORKSYSTEMINITPROC pInit = (PFNWNETWORKSYSTEMINITPROC)0x00A3AD40u;
+	PFNWNETWORKSYSTEMSENDMESSAGEAPROC pSendMessageA = (PFNWNETWORKSYSTEMSENDMESSAGEAPROC)0x00A3ADB0u;
+	PFNCONSTRUCTORWSENDPACKETPROC pConstructorWSendPacket = (PFNCONSTRUCTORWSENDPACKETPROC)0x00A3BEE0u;
+	PFNDESTRUCTORWSENDPACKETPROC pDestructorWSendPacket = (PFNDESTRUCTORWSENDPACKETPROC)0x00A3BCD0u;
+	PFNWSENDPACKETSENDPROC pSend = (PFNWSENDPACKETSENDPROC)0x00A3B340u;
+	PFNCLOBBYMAINCLEARTOOLTIPPROC pClearToolTip = (PFNCLOBBYMAINCLEARTOOLTIPPROC)0x00656770u;
+	PFNFRLOGINRSDLGSETSTATEPROC pSetState = (PFNFRLOGINRSDLGSETSTATEPROC)0x00AC4380u;
+
+	const char* gRankingDisabledServiceMsg = (const char*)0x00D244E8u;
+	void* gCSharedDocInstance = (*(void**)0x00E10FACu);
+	void* gWNetworkSystemInstance = (*(void**)0x00E3CFD0);
+	void* gFresh = (*(void**)0x00EC9640);
+
+	if (CALLTHISFUNCTION(pIsControlServerService, gCSharedDocInstance, 0x10000u) != 0u) {
+
+		if (_this == NULL)
+			return;
+
+		stMsgObject msg = MakeMsgObject(_this, 0x23u, (uint32_t)pBrasilTranslateString(gRankingDisabledServiceMsg), 0u, 0u, 0u, 0u);
+
+		CALLTHISVIRTUALCALL(PFNVIRTUALIACTORHANDLEMSGPROC, 0x2Cu, _this, &msg);
+
+		return;
+	}
+
+	CALLTHISVIRTUALCALL(PFNVIRTUALIACTORCLOSEALLDIALOGSPROC, 0x3Cu, _this);
+
+	if (CALLTHISFUNCTION(pIsConnected, gWNetworkSystemInstance, 0) == FALSE) {
+
+		CALLTHISFUNCTION(pInit, gWNetworkSystemInstance, 3);
+		CALLTHISFUNCTION(pSendMessageA, gWNetworkSystemInstance, 3, 0);
+	
+	}else {
+
+		uint8_t WSendPacketObject[40u];
+
+		CALLTHISFUNCTION(pConstructorWSendPacket, (void*)WSendPacketObject, 0x47u);
+		CALLTHISFUNCTION(pSend, (void*)WSendPacketObject, 0);
+		CALLTHISFUNCTION(pDestructorWSendPacket, (void*)WSendPacketObject);
+	}
+
+	void* FormWndObject = *GETTHISPOINTERMEMBER(void*, 0x160u, _this);
+
+	if (FormWndObject == NULL) {
+
+		FormWndObject = CreateFormFrLoginRsDlg(*GETTHISPOINTERMEMBER(void*, 0x40u, gFresh), (void*)GETTHISPOINTERMEMBER(void*, 0x18, _this), "login_gs", NULL);
+
+		pSetState(1u);
+
+		CALLTHISVIRTUALCALL(PFNFRFORMOPENPROC, 0x64u, FormWndObject, OnLoginRsDlgResult, 0xFFFFFFE8u, 0, 0, 0x41);
+	}
+
+	CALLTHISFUNCTION(pClearToolTip, _this, NULL);
+
+	return;
+}

--- a/src/patch_usa_852.h
+++ b/src/patch_usa_852.h
@@ -1,0 +1,12 @@
+#ifndef PATCH_USA_852_H
+#define PATCH_USA_852_H
+
+#include "common.h"
+#include <stdint.h>
+
+// C not have __thiscall
+#define __thiscall __fastcall
+
+void __thiscall OnUnderBar_RankingUp(void* _this);
+
+#endif


### PR DESCRIPTION
Fix for ProjectG USA version 852.00.

* Enabling cookie items in the shop that have been disabled.
* Activating the cookie refill button.
* Activating the ticker button.
* Activating the Gacha button.
* Activating the nickname change button
* Activating the ranking system.

Note:
Compiled in Microsoft Visual Studio Community 2017.
I didn't compile it in MinGW or Watcom