### PR TITLE
Adds URL rewriting in WebBrowser and WinInet GET, POST and POST with file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ OBJS := \
 	obj/hooks/ws2_32/redir.o \
 	obj/hooks/wininet/netredir.o \
 	obj/hooks/comctl32/dynamic_patch.o \
+	obj/hooks/ole32/web_browser.o \
 	obj/hooks/hooks.o \
 	obj/ld.o \
 	obj/common.o \

--- a/rugburn.vcxproj
+++ b/rugburn.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="src\config.c" />
     <ClCompile Include="src\dll\rugburn\main.c" />
     <ClCompile Include="src\hex.c" />
+    <ClCompile Include="src\hooks\ole32\web_browser.c" />
     <ClCompile Include="src\ijl15.c" />
     <ClCompile Include="src\hooks\comctl32\dynamic_patch.c" />
     <ClCompile Include="src\hooks\hooks.c" />

--- a/rugburn.vcxproj.filters
+++ b/rugburn.vcxproj.filters
@@ -18,6 +18,7 @@
     <ClCompile Include="src\hooks\wininet\netredir.c" />
     <ClCompile Include="src\hooks\ws2_32\redir.c" />
     <ClCompile Include="src\dll\rugburn\main.c" />
+    <ClCompile Include="src\hooks\ole32\web_browser.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LICENSE.md" />

--- a/rugburn_test.vcxproj
+++ b/rugburn_test.vcxproj
@@ -110,6 +110,7 @@
     <ClCompile Include="src\hooks\hooks.c" />
     <ClCompile Include="src\hooks\kernel32\inject.c" />
     <ClCompile Include="src\hooks\msvcr100\msvcr100.c" />
+    <ClCompile Include="src\hooks\ole32\web_browser.c" />
     <ClCompile Include="src\hooks\projectg\us852\ranking.c" />
     <ClCompile Include="src\hooks\user32\window.c" />
     <ClCompile Include="src\hooks\wininet\netredir.c" />

--- a/rugburn_test.vcxproj.filters
+++ b/rugburn_test.vcxproj.filters
@@ -18,6 +18,7 @@
     <ClCompile Include="src\hooks\wininet\netredir.c" />
     <ClCompile Include="src\hooks\ws2_32\redir.c" />
     <ClCompile Include="src\exe\test\main.c" />
+    <ClCompile Include="src\hooks\ole32\web_browser.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LICENSE.md" />

--- a/src/common-fnptr.h
+++ b/src/common-fnptr.h
@@ -27,7 +27,463 @@
 #include <ws2tcpip.h>
 
 // IWebBrowser 1 and 2
+#ifdef __MINGW32__
+#ifndef __IWebBrowser2_FWD_DEFINED__
+#define __IWebBrowser2_FWD_DEFINED__
+typedef struct IWebBrowser2 IWebBrowser2;
+
+#endif /* __IWebBrowser2_FWD_DEFINED__ */
+
+typedef /* [v1_enum] */
+enum tagREADYSTATE {
+    READYSTATE_UNINITIALIZED = 0,
+    READYSTATE_LOADING = 1,
+    READYSTATE_LOADED = 2,
+    READYSTATE_INTERACTIVE = 3,
+    READYSTATE_COMPLETE = 4
+} READYSTATE;
+
+typedef 
+enum OLECMDF
+{
+    OLECMDF_SUPPORTED	= 0x1,
+    OLECMDF_ENABLED	= 0x2,
+    OLECMDF_LATCHED	= 0x4,
+    OLECMDF_NINCHED	= 0x8,
+    OLECMDF_INVISIBLE	= 0x10,
+    OLECMDF_DEFHIDEONCTXTMENU	= 0x20
+} 	OLECMDF;
+
+typedef 
+enum OLECMDID
+{
+    OLECMDID_OPEN	= 1,
+    OLECMDID_NEW	= 2,
+    OLECMDID_SAVE	= 3,
+    OLECMDID_SAVEAS	= 4,
+    OLECMDID_SAVECOPYAS	= 5,
+    OLECMDID_PRINT	= 6,
+    OLECMDID_PRINTPREVIEW	= 7,
+    OLECMDID_PAGESETUP	= 8,
+    OLECMDID_SPELL	= 9,
+    OLECMDID_PROPERTIES	= 10,
+    OLECMDID_CUT	= 11,
+    OLECMDID_COPY	= 12,
+    OLECMDID_PASTE	= 13,
+    OLECMDID_PASTESPECIAL	= 14,
+    OLECMDID_UNDO	= 15,
+    OLECMDID_REDO	= 16,
+    OLECMDID_SELECTALL	= 17,
+    OLECMDID_CLEARSELECTION	= 18,
+    OLECMDID_ZOOM	= 19,
+    OLECMDID_GETZOOMRANGE	= 20,
+    OLECMDID_UPDATECOMMANDS	= 21,
+    OLECMDID_REFRESH	= 22,
+    OLECMDID_STOP	= 23,
+    OLECMDID_HIDETOOLBARS	= 24,
+    OLECMDID_SETPROGRESSMAX	= 25,
+    OLECMDID_SETPROGRESSPOS	= 26,
+    OLECMDID_SETPROGRESSTEXT	= 27,
+    OLECMDID_SETTITLE	= 28,
+    OLECMDID_SETDOWNLOADSTATE	= 29,
+    OLECMDID_STOPDOWNLOAD	= 30,
+    OLECMDID_ONTOOLBARACTIVATED	= 31,
+    OLECMDID_FIND	= 32,
+    OLECMDID_DELETE	= 33,
+    OLECMDID_HTTPEQUIV	= 34,
+    OLECMDID_HTTPEQUIV_DONE	= 35,
+    OLECMDID_ENABLE_INTERACTION	= 36,
+    OLECMDID_ONUNLOAD	= 37,
+    OLECMDID_PROPERTYBAG2	= 38,
+    OLECMDID_PREREFRESH	= 39,
+    OLECMDID_SHOWSCRIPTERROR	= 40,
+    OLECMDID_SHOWMESSAGE	= 41,
+    OLECMDID_SHOWFIND	= 42,
+    OLECMDID_SHOWPAGESETUP	= 43,
+    OLECMDID_SHOWPRINT	= 44,
+    OLECMDID_CLOSE	= 45,
+    OLECMDID_ALLOWUILESSSAVEAS	= 46,
+    OLECMDID_DONTDOWNLOADCSS	= 47,
+    OLECMDID_UPDATEPAGESTATUS	= 48,
+    OLECMDID_PRINT2	= 49,
+    OLECMDID_PRINTPREVIEW2	= 50,
+    OLECMDID_SETPRINTTEMPLATE	= 51,
+    OLECMDID_GETPRINTTEMPLATE	= 52,
+    OLECMDID_PAGEACTIONBLOCKED	= 55,
+    OLECMDID_PAGEACTIONUIQUERY	= 56,
+    OLECMDID_FOCUSVIEWCONTROLS	= 57,
+    OLECMDID_FOCUSVIEWCONTROLSQUERY	= 58,
+    OLECMDID_SHOWPAGEACTIONMENU	= 59,
+    OLECMDID_ADDTRAVELENTRY	= 60,
+    OLECMDID_UPDATETRAVELENTRY	= 61,
+    OLECMDID_UPDATEBACKFORWARDSTATE	= 62,
+    OLECMDID_OPTICAL_ZOOM	= 63,
+    OLECMDID_OPTICAL_GETZOOMRANGE	= 64,
+    OLECMDID_WINDOWSTATECHANGED	= 65,
+    OLECMDID_ACTIVEXINSTALLSCOPE	= 66,
+    OLECMDID_UPDATETRAVELENTRY_DATARECOVERY	= 67,
+    OLECMDID_SHOWTASKDLG	= 68,
+    OLECMDID_POPSTATEEVENT	= 69,
+    OLECMDID_VIEWPORT_MODE	= 70,
+    OLECMDID_LAYOUT_VIEWPORT_WIDTH	= 71,
+    OLECMDID_VISUAL_VIEWPORT_EXCLUDE_BOTTOM	= 72,
+    OLECMDID_USER_OPTICAL_ZOOM	= 73,
+    OLECMDID_PAGEAVAILABLE	= 74,
+    OLECMDID_GETUSERSCALABLE	= 75,
+    OLECMDID_UPDATE_CARET	= 76,
+    OLECMDID_ENABLE_VISIBILITY	= 77,
+    OLECMDID_MEDIA_PLAYBACK	= 78,
+    OLECMDID_SETFAVICON	= 79,
+    OLECMDID_SET_HOST_FULLSCREENMODE	= 80,
+    OLECMDID_EXITFULLSCREEN	= 81,
+    OLECMDID_SCROLLCOMPLETE	= 82,
+    OLECMDID_ONBEFOREUNLOAD	= 83,
+    OLECMDID_SHOWMESSAGE_BLOCKABLE	= 84,
+    OLECMDID_SHOWTASKDLG_BLOCKABLE	= 85
+} 	OLECMDID;
+
+typedef 
+enum OLECMDEXECOPT
+{
+    OLECMDEXECOPT_DODEFAULT	= 0,
+    OLECMDEXECOPT_PROMPTUSER	= 1,
+    OLECMDEXECOPT_DONTPROMPTUSER	= 2,
+    OLECMDEXECOPT_SHOWHELP	= 3
+} 	OLECMDEXECOPT;
+
+typedef 
+struct IWebBrowser2Vtbl
+{
+
+	BEGIN_INTERFACE
+        
+    HRESULT ( STDCALL *QueryInterface )( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in REFIID riid,
+        /* [annotation][iid_is][out] */ 
+        _COM_Outptr_  void **ppvObject);
+        
+    ULONG(STDCALL *AddRef)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    ULONG(STDCALL *Release)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    HRESULT(STDCALL *GetTypeInfoCount)
+    ( 
+        __RPC__in IWebBrowser2 * This,
+        /* [out] */ __RPC__out UINT *pctinfo);
+        
+    HRESULT(STDCALL *GetTypeInfo)
+    ( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ UINT iTInfo,
+        /* [in] */ LCID lcid,
+        /* [out] */ __RPC__deref_out_opt ITypeInfo **ppTInfo);
+        
+    HRESULT(STDCALL *GetIDsOfNames)
+    ( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in REFIID riid,
+        /* [size_is][in] */ __RPC__in_ecount_full(cNames) LPOLESTR *rgszNames,
+        /* [range][in] */ __RPC__in_range(0,16384) UINT cNames,
+        /* [in] */ LCID lcid,
+        /* [size_is][out] */ __RPC__out_ecount_full(cNames) DISPID *rgDispId);
+        
+    /* [local] */ HRESULT(STDCALL *Invoke)( 
+        IWebBrowser2 * This,
+        /* [annotation][in] */ 
+        _In_  DISPID dispIdMember,
+        /* [annotation][in] */ 
+        _In_  REFIID riid,
+        /* [annotation][in] */ 
+        _In_  LCID lcid,
+        /* [annotation][in] */ 
+        _In_  WORD wFlags,
+        /* [annotation][out][in] */ 
+        _In_  DISPPARAMS *pDispParams,
+        /* [annotation][out] */ 
+        _Out_opt_  VARIANT *pVarResult,
+        /* [annotation][out] */ 
+        _Out_opt_  EXCEPINFO *pExcepInfo,
+        /* [annotation][out] */ 
+        _Out_opt_  UINT *puArgErr);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *GoBack)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *GoForward)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *GoHome)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *GoSearch)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Navigate)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in BSTR URL,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *Flags,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *TargetFrameName,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *PostData,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *Headers);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Refresh)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Refresh2)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *Level);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Stop)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Application)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt IDispatch **ppDisp);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Parent)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt IDispatch **ppDisp);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Container)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt IDispatch **ppDisp);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Document)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt IDispatch **ppDisp);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_TopLevelContainer)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pBool);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Type)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *Type);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Left)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out long *pl);
+        
+    /* [propput][id] */ HRESULT(STDCALL *put_Left)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ long Left);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Top)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out long *pl);
+        
+    /* [propput][id] */ HRESULT(STDCALL *put_Top)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ long Top);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Width)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out long *pl);
+        
+    /* [propput][id] */ HRESULT(STDCALL *put_Width)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ long Width);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Height)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out long *pl);
+        
+    /* [propput][id] */ HRESULT(STDCALL *put_Height)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ long Height);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_LocationName)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *LocationName);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_LocationURL)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *LocationURL);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Busy)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pBool);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Quit)( 
+        __RPC__in IWebBrowser2 * This);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *ClientToWindow)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [out][in] */ __RPC__inout int *pcx,
+        /* [out][in] */ __RPC__inout int *pcy);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *PutProperty)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in BSTR Property,
+        /* [in] */ VARIANT vtValue);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *GetProperty)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in BSTR Property,
+        /* [retval][out] */ __RPC__out VARIANT *pvtValue);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Name)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *Name);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_HWND)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out SHANDLE_PTR *pHWND);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_FullName)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *FullName);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Path)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *Path);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Visible)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pBool);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_Visible)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL Value);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_StatusBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pBool);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_StatusBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL Value);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_StatusText)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__deref_out_opt BSTR *StatusText);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_StatusText)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in BSTR StatusText);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_ToolBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out int *Value);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_ToolBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ int Value);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_MenuBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *Value);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_MenuBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL Value);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_FullScreen)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbFullScreen);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_FullScreen)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bFullScreen);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *Navigate2)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in VARIANT *URL,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *Flags,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *TargetFrameName,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *PostData,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *Headers);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *QueryStatusWB)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ OLECMDID cmdID,
+        /* [retval][out] */ __RPC__out OLECMDF *pcmdf);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *ExecWB)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ OLECMDID cmdID,
+        /* [in] */ OLECMDEXECOPT cmdexecopt,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *pvaIn,
+        /* [unique][optional][out][in] */ __RPC__inout_opt VARIANT *pvaOut);
+        
+    /* [helpcontext][helpstring][id] */ HRESULT(STDCALL *ShowBrowserBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ __RPC__in VARIANT *pvaClsid,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *pvarShow,
+        /* [unique][optional][in] */ __RPC__in_opt VARIANT *pvarSize);
+        
+    /* [bindable][propget][id] */ HRESULT(STDCALL *get_ReadyState)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [out][retval] */ __RPC__out READYSTATE *plReadyState);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Offline)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbOffline);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_Offline)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bOffline);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Silent)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbSilent);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_Silent)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bSilent);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_RegisterAsBrowser)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbRegister);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_RegisterAsBrowser)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bRegister);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_RegisterAsDropTarget)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbRegister);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_RegisterAsDropTarget)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bRegister);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_TheaterMode)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *pbRegister);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_TheaterMode)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL bRegister);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_AddressBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *Value);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_AddressBar)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL Value);
+        
+    /* [helpcontext][helpstring][propget][id] */ HRESULT(STDCALL *get_Resizable)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [retval][out] */ __RPC__out VARIANT_BOOL *Value);
+        
+    /* [helpcontext][helpstring][propput][id] */ HRESULT(STDCALL *put_Resizable)( 
+        __RPC__in IWebBrowser2 * This,
+        /* [in] */ VARIANT_BOOL Value);
+        
+    END_INTERFACE
+} IWebBrowser2Vtbl;
+
+struct IWebBrowser2 {
+    CONST_VTBL struct IWebBrowser2Vtbl *lpVtbl;
+};
+#else
 #include <ExDisp.h>
+#endif
 
 #ifdef __MINGW32__
 

--- a/src/common-fnptr.h
+++ b/src/common-fnptr.h
@@ -26,6 +26,9 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 
+// IWebBrowser 1 and 2
+#include <ExDisp.h>
+
 #ifdef __MINGW32__
 
 typedef struct _DNS_QUERY_REQUEST {
@@ -52,6 +55,24 @@ typedef struct tagINITCOMMONCONTROLSEX {
 
 // comctl32.dll
 typedef BOOL(STDCALL *PFNINITCOMMONCONTROLSEXPROC)(const INITCOMMONCONTROLSEX *picce);
+
+// ole32.dll
+typedef HRESULT(STDCALL *PFNCOGETCLASSOBJECTPROC)(REFCLSID rclsid, DWORD dwClsContext,
+                                                  LPVOID pvReserved, REFIID riid, LPVOID *ppv);
+typedef HRESULT(STDCALL *PFNCOCREATEINSTANCEPROC)(REFCLSID rclsid, LPUNKNOWN pUnkOuter,
+                                                  DWORD dwClsContext, REFIID riid, LPVOID *ppv);
+
+// oleaut32.dll
+typedef BSTR (STDCALL *PFNSYSALLOCSTRINGPROC)(const OLECHAR *psz);
+typedef void (STDCALL *PFNSYSFREESTRINGPROC)(BSTR bstrString);
+
+// ieframe.dll
+typedef HRESULT(STDCALL *PFNINVOKEPROC)(IDispatch *This, DISPID dispIdMember, REFIID riid,
+                                        LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+                                        VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+typedef HRESULT(STDCALL *PFNNAVIGATEPROC)(IWebBrowser2 *This, BSTR URL, VARIANT *Flags,
+                                          VARIANT *TargetFrameName, VARIANT *PostData,
+                                          VARIANT *Headers);
 
 // general
 typedef BOOL(WINAPI *PFNDLLMAINPROC)(HANDLE, DWORD, LPVOID);
@@ -141,10 +162,39 @@ typedef VOID(STDCALL *PFNGETSTARTUPINFOAPROC)(LPSTARTUPINFOA lpStartupInfo);
 typedef VOID(STDCALL *PFNGETSTARTUPINFOWPROC)(LPSTARTUPINFOW lpStartupInfo);
 
 // wininet.dll
-typedef void(STDCALL *PFNINTERNETCONNECTAPROC)(HINTERNET, LPCSTR, INTERNET_PORT, LPCSTR, LPCSTR,
-                                               DWORD, DWORD, DWORD_PTR);
 typedef HINTERNET(STDCALL *PFNINTERNETOPENURLAPROC)(HINTERNET, LPCSTR, LPCSTR, DWORD, DWORD,
                                                     DWORD_PTR);
+typedef HINTERNET(STDCALL *PFNINTERNETCONNECTAPROC)(HINTERNET hInternet, LPCSTR lpszServerName,
+                                                    INTERNET_PORT nServerPort, LPCSTR lpszUserName,
+                                                    LPCSTR lpszPassword, DWORD dwService,
+                                                    DWORD dwFlags, DWORD_PTR dwContext);
+typedef HINTERNET(STDCALL *PFNHTTPOPENREQUESTAPROC)(HINTERNET hConnect, LPCSTR lpszVerb,
+                                                    LPCSTR lpszObjectName, LPCSTR lpszVersion,
+                                                    LPCSTR lpszReferrer, LPCSTR *lplpszAcceptTypes,
+                                                    DWORD dwFlags, DWORD_PTR dwContext);
+typedef BOOL(STDCALL *PFNHTTPSENDREQUESTAPROC)(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                               DWORD dwHeadersLength, LPVOID lpOptional,
+                                               DWORD dwOptionalLength);
+typedef BOOL(STDCALL *PFNHTTPSENDREQUESTEXAPROC)(HINTERNET hRequest,
+                                                 LPINTERNET_BUFFERSA lpBuffersIn,
+                                                 LPINTERNET_BUFFERSA lpBuffersOut, DWORD dwFlags,
+                                                 DWORD_PTR dwContext);
+typedef BOOL(STDCALL *PFNHTTPENDREQUESTAPROC)(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersOut,
+                                              DWORD dwFlags, DWORD_PTR dwContext);
+typedef BOOL(STDCALL *PFNHTTPADDREQUESTHEADERSAPROC)(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                                     DWORD dwHeadersLength, DWORD dwModifiers);
+typedef BOOL(STDCALL *PFNHTTPQUERYINFOAPROC)(HINTERNET hRequest, DWORD dwInfoLevel, LPVOID lpBuffer,
+                                             LPDWORD lpdwBufferLength, LPDWORD lpdwIndex);
+typedef BOOL(STDCALL *PFNINTERNETCLOSEHANDLEPROC)(HINTERNET hInternet);
+typedef BOOL(STDCALL *PFNINTERNETWRITEFILEPROC)(HINTERNET hFile, LPCVOID lpBuffer,
+                                                DWORD dwNumberOfBytesToWrite,
+                                                LPDWORD lpdwNumberOfBytesWritten);
+typedef BOOL(STDCALL *PFNINTERNETQUERYOPTIONAPROC)(HINTERNET hInternet, DWORD dwOption,
+                                                   LPVOID lpBuffer, LPDWORD lpdwBufferLength);
+typedef BOOL(STDCALL *PFNINTERNETSETOPTIONAPROC)(HINTERNET hInternet, DWORD dwOption,
+                                                 LPVOID lpBuffer, DWORD dwBufferLength);
+typedef BOOL(STDCALL *PFNINTERNETCRACKURLAPROC)(LPCSTR lpszUrl, DWORD dwUrlLength, DWORD dwFlags,
+                                                LPURL_COMPONENTSA lpUrlComponents);
 
 // winmm.dll
 typedef DWORD(STDCALL *PFNTIMEGETTIMEPROC)();

--- a/src/common.c
+++ b/src/common.c
@@ -79,7 +79,7 @@ PSTR GetSelfPath() {
     return pszSelfPath;
 }
 
-BOOL FileExists(LPCTSTR szPath) { return GetFileAttributesA(szPath) != INVALID_FILE_ATTRIBUTES; }
+BOOL FileExists(LPCSTR szPath) { return GetFileAttributesA(szPath) != INVALID_FILE_ATTRIBUTES; }
 
 LPSTR ReadEntireFile(LPCSTR szPath, LPDWORD dwFileSize) {
     HANDLE hFile = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -83,6 +83,18 @@ void ReadJsonPatchAddressMap(LPSTR *json, LPCSTR key) {
     Config.NumPatchAddress++;
 }
 
+void ReadJsonBypassSelfSignedCertificate(LPSTR *json, LPCSTR key) {
+    LPCSTR value = JsonReadString(json);
+
+	Config.bBypassSelfSignedCertificate = FALSE;
+
+	if (value == NULL || value == "")
+		return;
+
+	if (_stricmp(value, "TRUE") == 0)
+		Config.bBypassSelfSignedCertificate = TRUE;
+}
+
 void ReadJsonConfigMap(LPSTR *json, LPCSTR key) {
     if (!strcmp(key, "UrlRewrites")) {
         JsonReadMap(json, ReadJsonUrlRewriteRuleMap);
@@ -90,6 +102,8 @@ void ReadJsonConfigMap(LPSTR *json, LPCSTR key) {
         JsonReadArray(json, ReadJsonPortRewriteRuleArray);
     } else if (!strcmp(key, "PatchAddress")) {
         JsonReadMap(json, ReadJsonPatchAddressMap);
+    } else if (!strcmp(key, "BypassSelfSignedCertificate")) {
+        ReadJsonBypassSelfSignedCertificate(json, key);
     } else {
         FatalError("Unexpected JSON config key '%s'", key);
     }

--- a/src/config.h
+++ b/src/config.h
@@ -49,6 +49,8 @@ typedef struct _RUGBURNCONFIG {
 
     PATCHADDRESS PatchAddress[MAXPATCHADDRESS];
     int NumPatchAddress;
+
+    BOOL bBypassSelfSignedCertificate;
 } RUGBURNCONFIG, *LPRUGBURNCONFIG;
 
 extern RUGBURNCONFIG Config;

--- a/src/hooks/comctl32/dynamic_patch.c
+++ b/src/hooks/comctl32/dynamic_patch.c
@@ -259,6 +259,12 @@ void PatchGG_TH() {
     } else if (compare_virtual_memory(0x0064B60B, 0xFF77A0E8)) {
         Patch((LPVOID)0x0064B60B, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (TH S2 300b1)\r\n");
+    } else if (compare_virtual_memory(0x0066589B, 0xFF6E30E8)) {
+        Patch((LPVOID)0x0066589B, "\xE9\x00\x00\x00\x00", 5);
+        Log("Patched GG check routines (TH S2 312b)\r\n");
+    } else if (compare_virtual_memory(0x0066C24B, 0xFF6E40E8)) {
+        Patch((LPVOID)0x0066C24B, "\xE9\x00\x00\x00\x00", 5);
+        Log("Patched GG check routines (TH S2 321a)\r\n");
     } else if (compare_virtual_memory(0x0076F4F4, 0xFEBED7E8)) {
         Patch((LPVOID)0x0076F4F4, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (TH S4 580)\r\n");

--- a/src/hooks/hooks.c
+++ b/src/hooks/hooks.c
@@ -22,6 +22,7 @@
 #include "user32/window.h"
 #include "wininet/netredir.h"
 #include "ws2_32/redir.h"
+#include "ole32/web_browser.h"
 
 VOID InitHooks() {
     InitInjectHook();
@@ -30,4 +31,5 @@ VOID InitHooks() {
     InitNetRedirHook();
     InitRedirHook();
     InitComCtl32Hook();
+    InitWebBrowserHook();
 }

--- a/src/hooks/ole32/web_browser.c
+++ b/src/hooks/ole32/web_browser.c
@@ -1,0 +1,179 @@
+#include "web_browser.h"
+#include "../../config.h"
+#include "../../patch.h"
+
+static HMODULE hOle32Module = NULL;
+static HMODULE hOleAut32Module = NULL;
+static PFNCOGETCLASSOBJECTPROC pCoGetClassObject = NULL;
+static PFNCOCREATEINSTANCEPROC pCoCreateInstance = NULL;
+static PFNINVOKEPROC pInvoke = NULL;
+static PFNNAVIGATEPROC pNavigate = NULL;
+static PFNSYSALLOCSTRINGPROC pSysAllocString = NULL;
+static PFNSYSFREESTRINGPROC pSysFreeString = NULL;
+
+// {00000112-0000-0000-C000-000000000046}
+const IID kIID_IObject = {0x112, 0, 0, {0xC0, 0, 0, 0, 0, 0, 0, 0x46}};
+// {00020400-0000-0000-C000-000000000046}
+const IID kIID_IDispatch = {0x20400, 0, 0, {0xC0, 0, 0, 0, 0, 0, 0, 0x46}};
+// {00000001-0000-0000-C000-000000000046}
+const IID kIID_IClassFactory = {0x1, 0, 0, {0xC0, 0, 0, 0, 0, 0, 0, 0x46}};
+// {8856F961-340A-11D0-A96B-00C04FD705A2}
+const IID kIID_MicrosoftWebBrowser = {0x8856F961, 0x340A, 0x11D0, {0xA9, 0x6B, 0, 0xC0, 0x4F, 0xD7, 0x05, 0xA2}};
+// {D30C1661-CDAF-11d0-8A3E-00C04FC9E26E}
+const IID kIID_IWebBrowser2 = {0xD30C1661, 0xCDAF, 0x11D0, {0x8A, 0x3E, 0, 0xC0, 0x4F, 0xC9, 0xE2, 0x6E}};
+
+BSTR RewriteURLW(BSTR urlw) {
+
+	int len_urlw = lstrlenW(urlw);
+    int len = WideCharToMultiByte(CP_ACP, 0, urlw, len_urlw, NULL, 0, NULL, NULL);
+
+	PCHAR url = AllocMem(len + 1);
+
+	WideCharToMultiByte(CP_ACP, 0, urlw, len_urlw, url, len, NULL, NULL);
+
+	url[len] = '\0';
+
+	LPCSTR newURLA = RewriteURL(url);
+
+	FreeMem(url);
+
+	if (newURLA != NULL) {
+
+		len = lstrlenA(newURLA);
+
+		len_urlw = MultiByteToWideChar(CP_ACP, 0, newURLA, len, NULL, 0);
+
+		LPOLESTR newURLW = AllocMem((len_urlw + 1) * sizeof(OLECHAR));
+
+		MultiByteToWideChar(CP_ACP, 0, newURLA, len, newURLW, len_urlw);
+
+		newURLW[len_urlw] = '\0';
+
+		FreeMem((HLOCAL)newURLA);
+
+		BSTR newURLBSTR = pSysAllocString(newURLW);
+
+		FreeMem(newURLW);
+
+		return newURLBSTR;
+	}
+
+	return NULL;
+}
+
+HRESULT InvokeHook(IDispatch *This, DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) {
+
+	BSTR newURL = NULL;
+
+	for (unsigned int i = 0u; i < pDispParams->cArgs; i++) {
+
+		if (pDispParams->rgvarg[i].vt == VT_BSTR) {
+
+			newURL = RewriteURLW(pDispParams->rgvarg[i].bstrVal);
+			if (newURL != NULL) {
+				Log("IDispatch->Invoke(%S -> %S)\r\n", pDispParams->rgvarg[i].bstrVal, newURL);
+				pSysFreeString(pDispParams->rgvarg[i].bstrVal);
+				pDispParams->rgvarg[i].bstrVal = newURL;
+			} else {
+				Log("IDispatch->Invoke(%S) // (no rewrite rules matched)\r\n", pDispParams->rgvarg[i].bstrVal);
+			}
+		}
+	}
+
+	return pInvoke(This, dispIdMember, riid, lcid, wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
+}
+
+HRESULT STDCALL NavigateHook(IWebBrowser2 *This, BSTR URL, VARIANT *Flags, VARIANT *TargetFrameName, VARIANT *PostData, VARIANT *Headers) {
+
+	BSTR newURL = NULL;
+
+	newURL = RewriteURLW(URL);
+	if (newURL != NULL) {
+		Log("IWebBrowser2->Navigate(%S -> %S)\r\n", URL, newURL);
+		pSysFreeString(URL);
+		URL = newURL;
+	} else {
+		Log("IWebBrowser2->Navigate(%S) // (no rewrite rules matched)\r\n", URL);
+	}
+
+	return pNavigate(This, URL, Flags, TargetFrameName, PostData, Headers);
+}
+
+HRESULT STDCALL CoGetClassObjectHook(REFCLSID rclsid, DWORD dwClsContext, LPVOID pvReserved, REFIID riid, LPVOID *ppv) {
+
+    static void *g_pInvoke = NULL;
+
+	HRESULT ret = pCoGetClassObject(rclsid, dwClsContext, pvReserved, riid, ppv);
+
+	if (ret >= 0) {
+		
+        if (memcmp(rclsid, &kIID_MicrosoftWebBrowser, sizeof(IID)) == 0) {
+
+			IClassFactory *obj = (IClassFactory*)*ppv;
+
+			IDispatch *iDispatch1 = NULL;
+			IDispatch *iDispatch2 = NULL;
+
+			HRESULT ret2 = obj->lpVtbl->CreateInstance(obj, NULL, &kIID_IObject, (LPVOID*)&iDispatch1);
+
+			if (ret2 < 0) {
+				Log("CreateInstance failed. %d\r\n", ret2);
+				return ret;
+			}
+
+			ret2 = iDispatch1->lpVtbl->QueryInterface(iDispatch1, &kIID_IDispatch, (LPVOID*)&iDispatch2);
+
+			if (ret2 < 0) {
+				Log("QueryInterface failed. %d\r\n", ret2);
+				return ret;
+			}
+
+			if (g_pInvoke != iDispatch2->lpVtbl->Invoke) {
+				g_pInvoke = iDispatch2->lpVtbl->Invoke;
+				pInvoke = HookFunc(g_pInvoke, InvokeHook);
+				Log("Install InvokeHook(0x%08p): 0x%08p -> 0x%08p\r\n", g_pInvoke, InvokeHook, pInvoke);
+			}
+		}
+	}
+
+	return ret;
+}
+
+HRESULT STDCALL CoCreateInstanceHook(REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFIID riid, LPVOID *ppv) {
+
+    static void *g_pNavigate = NULL;
+
+	HRESULT ret = pCoCreateInstance(rclsid, pUnkOuter, dwClsContext, riid, ppv);
+
+	if (ret >= 0) {
+
+		if (memcmp(rclsid, &kIID_MicrosoftWebBrowser, sizeof(IID)) == 0) {
+
+			IUnknown *obj = *ppv;
+            IWebBrowser2 *webbrowser2 = NULL;
+
+			HRESULT ret2 = obj->lpVtbl->QueryInterface(obj, &kIID_IWebBrowser2, (LPVOID*)&webbrowser2);
+            if (ret2 < 0) {
+				Log("QueryInterface failed. %d\r\n", ret2);
+				return ret;
+            }
+			
+			if (g_pNavigate != webbrowser2->lpVtbl->Navigate) {
+				g_pNavigate = webbrowser2->lpVtbl->Navigate;
+				pNavigate = HookFunc(g_pNavigate, NavigateHook);
+				Log("Install NavigateHook(0x%08p): 0x%08p -> 0x%08p\r\n", g_pNavigate, NavigateHook, pNavigate);
+			}
+		}
+	}
+
+    return ret;
+}
+
+void InitWebBrowserHook() {
+	hOle32Module = LoadLib("ole32");
+    hOleAut32Module = LoadLib("oleaut32");
+    pSysAllocString = GetProc(hOleAut32Module, "SysAllocString");
+	pSysFreeString = GetProc(hOleAut32Module, "SysFreeString");
+    pCoGetClassObject = HookProc(hOle32Module, "CoGetClassObject", CoGetClassObjectHook);
+	pCoCreateInstance = HookProc(hOle32Module, "CoCreateInstance", CoCreateInstanceHook);
+}

--- a/src/hooks/ole32/web_browser.h
+++ b/src/hooks/ole32/web_browser.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "../../common.h"
+
+void InitWebBrowserHook();

--- a/src/hooks/wininet/netredir.c
+++ b/src/hooks/wininet/netredir.c
@@ -20,6 +20,401 @@
 
 HMODULE hWinINet = NULL;
 PFNINTERNETOPENURLAPROC pInternetOpenUrlA = NULL;
+PFNINTERNETCONNECTAPROC pInternetConnectA = NULL;
+PFNHTTPOPENREQUESTAPROC pHttpOpenRequestA = NULL;
+PFNHTTPSENDREQUESTAPROC pHttpSendRequestA = NULL;
+PFNHTTPSENDREQUESTEXAPROC pHttpSendRequestExA = NULL;
+PFNHTTPENDREQUESTAPROC pHttpEndRequestA = NULL;
+PFNHTTPADDREQUESTHEADERSAPROC pHttpAddRequestHeadersA = NULL;
+PFNHTTPQUERYINFOAPROC pHttpQueryInfoA = NULL;
+PFNINTERNETCLOSEHANDLEPROC pInternetCloseHandle = NULL;
+PFNINTERNETWRITEFILEPROC pInternetWriteFile = NULL;
+PFNINTERNETQUERYOPTIONAPROC pInternetQueryOptionA = NULL;
+PFNINTERNETSETOPTIONAPROC pInternetSetOptionA = NULL;
+PFNINTERNETCRACKURLAPROC pInternetCrackUrlA = NULL;
+
+typedef struct _http_header {
+    LPCSTR lpszHeaders;
+    DWORD dwHeaderLength;
+    DWORD dwModifiers;
+} http_header;
+
+#define MAX_HTTP_HEADER 30
+
+typedef struct _internet_ctx {
+    struct _internet_ctx *_next;
+    struct _internet_ctx *_prev;
+    HINTERNET hOpen;
+    HINTERNET hConnect;
+    HINTERNET hNewConnect;
+    HINTERNET hRequest;
+    LPSTR lpszMethod;
+    LPCSTR *rgpszAcceptTypes;
+    LPSTR lpszServerName;
+    INTERNET_PORT nServerPort;
+    LPSTR lpszUserName;
+    LPSTR lpszPassword;
+    DWORD dwService;
+    DWORD dwFlags;
+    DWORD_PTR dwContext;
+    http_header vHeaders[MAX_HTTP_HEADER];
+    DWORD nHeaders;
+    LPCVOID lpFileBuffer;
+    DWORD dwNumberOfBytesToWrite;
+    LPINTERNET_BUFFERSA lpBuffersIn;
+} internet_ctx;
+
+static internet_ctx g_inet_ctx;
+
+void insertInetCtx(internet_ctx *_ctx) {
+
+    internet_ctx *node = g_inet_ctx._next;
+
+    if (node == NULL) {
+        g_inet_ctx._next = _ctx;
+        _ctx->_next = NULL;
+        _ctx->_prev = &g_inet_ctx;
+    } else {
+
+        while (node != NULL) {
+            if (node->_next == NULL)
+                break;
+            node = node->_next;
+        }
+
+        node->_next = _ctx;
+        _ctx->_prev = node;
+        _ctx->_next = NULL;
+    }
+}
+
+void createInetCtx(HINTERNET hOpen, HINTERNET hConnect, LPCSTR lpszServerName,
+                   INTERNET_PORT nServerPort, LPCSTR lpszUserName, LPCSTR lpszPassword,
+                   DWORD dwService, DWORD dwFlags, DWORD_PTR dwContext, HINTERNET hRequest,
+                   HINTERNET hNewConnect) {
+
+    internet_ctx *ctx = AllocMem(sizeof(internet_ctx));
+
+    memset(ctx, 0, sizeof(*ctx));
+
+    ctx->_next = NULL;
+    ctx->_prev = NULL;
+    ctx->hOpen = hOpen;
+    ctx->hConnect = hConnect;
+    ctx->hNewConnect = hNewConnect;
+    ctx->hRequest = hRequest;
+    ctx->lpszMethod = NULL;
+    ctx->lpszServerName = NULL;
+    ctx->nServerPort = nServerPort;
+    ctx->lpszUserName = NULL;
+    ctx->lpszPassword = NULL;
+    ctx->dwService = dwService;
+    ctx->dwFlags = dwFlags;
+    ctx->dwContext = dwContext;
+
+    if (lpszServerName != NULL) {
+        int len = lstrlenA(lpszServerName);
+
+        ctx->lpszServerName = AllocMem(len + 1);
+        memcpy(ctx->lpszServerName, lpszServerName, len);
+        ctx->lpszServerName[len] = '\0';
+    }
+
+    if (lpszUserName != NULL) {
+        int len = lstrlenA(lpszUserName);
+
+        ctx->lpszUserName = AllocMem(len + 1);
+        memcpy(ctx->lpszUserName, lpszUserName, len);
+        ctx->lpszUserName[len] = '\0';
+    }
+
+    if (lpszPassword != NULL) {
+        int len = lstrlenA(lpszPassword);
+
+        ctx->lpszPassword = AllocMem(len + 1);
+        memcpy(ctx->lpszPassword, lpszPassword, len);
+        ctx->lpszPassword[len] = '\0';
+    }
+
+    insertInetCtx(ctx);
+}
+
+void destructInetCtx(internet_ctx *_ctx) {
+
+    if (_ctx == NULL)
+        return;
+
+    if (_ctx->lpszMethod != NULL)
+        FreeMem((HLOCAL)_ctx->lpszMethod);
+    if (_ctx->lpszServerName != NULL)
+        FreeMem((HLOCAL)_ctx->lpszServerName);
+    if (_ctx->lpszUserName != NULL)
+        FreeMem((HLOCAL)_ctx->lpszUserName);
+    if (_ctx->lpszPassword != NULL)
+        FreeMem((HLOCAL)_ctx->lpszPassword);
+
+    memset(_ctx, 0, sizeof(internet_ctx));
+}
+
+void removeInetCtx(internet_ctx *_ctx) {
+
+    if (_ctx == NULL || _ctx == &g_inet_ctx)
+        return;
+
+    // Invalid Node
+    if (_ctx->_next == NULL && _ctx->_prev == NULL) {
+        destructInetCtx(_ctx);
+        FreeMem((HLOCAL)_ctx);
+        return;
+    }
+
+    if (_ctx->_next != NULL)
+        _ctx->_next->_prev = _ctx->_prev;
+    if (_ctx->_prev != NULL)
+        _ctx->_prev->_next = _ctx->_next;
+
+    destructInetCtx(_ctx);
+    FreeMem((HLOCAL)_ctx);
+}
+
+internet_ctx *findInetCtxByConnect(HINTERNET hConnect) {
+
+    if (g_inet_ctx._next == NULL)
+        return NULL;
+
+    internet_ctx *node = g_inet_ctx._next;
+
+    do {
+
+        if (node->hConnect == hConnect)
+            return node;
+
+    } while ((node = node->_next) != NULL);
+
+    return NULL;
+}
+
+internet_ctx *findInetCtxByRequest(HINTERNET hRequest) {
+
+    if (g_inet_ctx._next == NULL)
+        return NULL;
+
+    internet_ctx *node = g_inet_ctx._next;
+
+    do {
+
+        if (node->hRequest == hRequest)
+            return node;
+
+    } while ((node = node->_next) != NULL);
+
+    return NULL;
+}
+
+int PortLength(INTERNET_PORT _port) {
+
+    if (_port == 80 || _port == 443)
+        return 0;
+
+    int length = 1; // ':' + 1
+
+    if (_port < 10)
+        return length + 1;
+    if (_port < 100)
+        return length + 2;
+    if (_port < 1000)
+        return length + 3;
+    if (_port < 10000)
+        return length + 4;
+    if (_port < 100000)
+        return length + 5;
+    if (_port < 1000000)
+        return length + 6;
+
+    return length + 7;
+}
+
+int UserNameAndPasswordLength(DWORD _dwUserNameLength, DWORD _dwPasswordLength) {
+
+    if (_dwUserNameLength == 0u && _dwPasswordLength == 0u)
+        return 0;
+
+    int length = _dwPasswordLength + _dwPasswordLength;
+
+    if (_dwUserNameLength > 0u && _dwPasswordLength > 0u)
+        length += 2;
+    else
+        length += 1;
+
+    return length;
+}
+
+HINTERNET STDCALL InternetOpenUrlABypasSelfSignedCertificate(HINTERNET hInternet, LPCSTR lpszUrl,
+                                                             LPCSTR lpszHeaders,
+                                                             DWORD dwHeadersLength, DWORD dwFlags,
+                                                             DWORD_PTR dwContext) {
+
+    URL_COMPONENTSA url_cpsa;
+    memset(&url_cpsa, 0, sizeof(URL_COMPONENTSA));
+    url_cpsa.dwStructSize = sizeof(URL_COMPONENTSA);
+    url_cpsa.dwSchemeLength = 10;
+    url_cpsa.dwHostNameLength = 512;
+    url_cpsa.dwUserNameLength = 256;
+    url_cpsa.dwPasswordLength = 256;
+
+    if (pInternetCrackUrlA(lpszUrl, lstrlenA(lpszUrl), 0, &url_cpsa) == FALSE) {
+        Log("InternetCrackUrlA failed. Error: %d\r\n", LastErr());
+        return NULL;
+    }
+
+    LPSTR lpszHostName =
+        (url_cpsa.dwHostNameLength == 0u ? NULL : AllocMem(url_cpsa.dwHostNameLength + 1));
+
+    if (lpszHostName != NULL) {
+        memcpy(lpszHostName, url_cpsa.lpszHostName, url_cpsa.dwHostNameLength);
+        lpszHostName[url_cpsa.dwHostNameLength] = '\0';
+    }
+
+    HINTERNET hConnect = pInternetConnectA(hInternet, lpszHostName, url_cpsa.nPort, NULL, NULL,
+                                           INTERNET_SERVICE_HTTP, dwFlags, dwContext);
+
+    if (hConnect == NULL) {
+        Log("InternetConnectA. failed Error: %d\r\n", LastErr());
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+        return NULL;
+    }
+
+    if (url_cpsa.nScheme == INTERNET_SCHEME_HTTPS)
+        dwFlags |= INTERNET_FLAG_SECURE;
+
+    if (Config.bBypassSelfSignedCertificate == TRUE)
+        dwFlags |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+
+    LPCSTR lpszNewObjectName =
+        (lpszUrl + url_cpsa.dwSchemeLength + 3 +
+         UserNameAndPasswordLength(url_cpsa.dwUserNameLength, url_cpsa.dwPasswordLength) +
+         url_cpsa.dwHostNameLength + PortLength(url_cpsa.nPort));
+
+    LPCSTR rgpszAcceptTypes[] = {"*/*", NULL};
+
+    HINTERNET hReq = pHttpOpenRequestA(hConnect, "GET", lpszNewObjectName, HTTP_VERSIONA, NULL,
+                                       rgpszAcceptTypes, dwFlags, dwContext);
+
+    if (hReq == NULL) {
+        Log("InternetOpenUrlABypassSeflsignedCertificate->HttpOpenRequestA. failed Error: %d\r\n",
+            LastErr());
+        pInternetCloseHandle(hConnect);
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+        return hReq;
+    }
+
+    BOOL ret2 = FALSE;
+
+    if (Config.bBypassSelfSignedCertificate == TRUE) {
+        DWORD dwFlags2;
+        DWORD dwBuffLen = sizeof(dwFlags2);
+
+        ret2 = pInternetQueryOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, &dwBuffLen);
+
+        if (ret2 == FALSE) {
+            Log("InternetQueryOptionA failed. Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            if (lpszHostName != NULL)
+                FreeMem((HLOCAL)lpszHostName);
+            return NULL;
+        }
+
+        dwFlags2 |= SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_WEAK_SIGNATURE |
+                    SECURITY_FLAG_IGNORE_WRONG_USAGE | SECURITY_FLAG_IGNORE_REVOCATION;
+
+        ret2 =
+            pInternetSetOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, sizeof(dwFlags2));
+
+        if (ret2 == FALSE) {
+            Log("InternetSetOptionA failed. Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            if (lpszHostName != NULL)
+                FreeMem((HLOCAL)lpszHostName);
+            return NULL;
+        }
+    }
+
+    ret2 = pHttpSendRequestA(hReq, lpszHeaders, dwHeadersLength, NULL, 0);
+
+    if (ret2 == FALSE) {
+        Log("HttpSendRequestA. failed Error: %d\r\n", LastErr());
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+        return NULL;
+    }
+
+    DWORD statusCode = 0;
+    DWORD dwStatusCodeLength = sizeof(statusCode);
+    ret2 = pHttpQueryInfoA(hReq, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER, &statusCode,
+                           &dwStatusCodeLength, NULL);
+    if (ret2 == FALSE) {
+        Log("HttpQueryInfoA(1). failed Error: %d\r\n", LastErr());
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+        return NULL;
+    }
+
+    if (statusCode == HTTP_STATUS_MOVED || statusCode == HTTP_STATUS_REDIRECT) {
+
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+
+        DWORD dwBuffLength = 0;
+        ret2 = pHttpQueryInfoA(hReq, HTTP_QUERY_LOCATION, NULL, &dwBuffLength, NULL);
+        if (ret2 == FALSE && (LastErr() != ERROR_INSUFFICIENT_BUFFER || dwBuffLength == 0)) {
+            Log("HttpQueryInfoA(2). failed Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            return NULL;
+        }
+
+        LPSTR buff = AllocMem(dwBuffLength + 1);
+
+        ret2 = pHttpQueryInfoA(hReq, HTTP_QUERY_LOCATION, buff, &dwBuffLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(3). failed Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            if (buff != NULL)
+                FreeMem((HLOCAL)buff);
+            return NULL;
+        }
+
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        hReq = NULL;
+
+        hReq = InternetOpenUrlABypasSelfSignedCertificate(hInternet, buff, lpszHeaders,
+                                                          dwHeadersLength, dwFlags, dwContext);
+
+        if (buff != NULL)
+            FreeMem((HLOCAL)buff);
+
+        return hReq;
+    }
+
+    // creates context to close the connect handle
+    createInetCtx(NULL, hInternet, lpszHostName, url_cpsa.nPort, NULL, NULL, INTERNET_SERVICE_HTTP,
+                  dwFlags, dwContext, hReq, hConnect);
+
+    if (lpszHostName != NULL)
+        FreeMem((HLOCAL)lpszHostName);
+
+    return hReq;
+}
 
 /**
  * InternetOpenUrlAHook redirects HTTP calls to localhost.
@@ -27,23 +422,835 @@ PFNINTERNETOPENURLAPROC pInternetOpenUrlA = NULL;
 HINTERNET STDCALL InternetOpenUrlAHook(HINTERNET hInternet, LPCSTR lpszUrl, LPCSTR lpszHeaders,
                                        DWORD dwHeadersLength, DWORD dwFlags, DWORD_PTR dwContext) {
     LPCSTR newURL;
+    LPCSTR refURL;
     HINTERNET hResult;
 
-    newURL = RewriteURL(lpszUrl);
+    // Manual redirect
+    dwFlags |= INTERNET_FLAG_NO_AUTO_REDIRECT;
+
+    refURL = newURL = RewriteURL(lpszUrl);
     if (newURL != NULL) {
         Log("InternetOpenUrlA(%s -> %s)\r\n", lpszUrl, newURL);
         hResult =
             pInternetOpenUrlA(hInternet, newURL, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
-        FreeMem((HLOCAL)newURL);
     } else {
-        Log("InternetOpenUrlA(%s) // (no rewrite rules matched)\r\n", lpszUrl, newURL);
+        newURL = lpszUrl;
+        Log("InternetOpenUrlA(%s) // (no rewrite rules matched)\r\n", newURL);
         hResult =
             pInternetOpenUrlA(hInternet, newURL, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
     }
+
+    if (hResult == NULL) {
+        DWORD error = LastErr();
+
+        if (Config.bBypassSelfSignedCertificate == TRUE &&
+            (error == ERROR_INTERNET_SEC_CERT_DATE_INVALID ||
+             error == ERROR_INTERNET_SEC_CERT_CN_INVALID || error == ERROR_INTERNET_INVALID_CA))
+            hResult = InternetOpenUrlABypasSelfSignedCertificate(
+                hInternet, newURL, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
+
+    } else {
+        DWORD statusCode = 0;
+        DWORD dwStatusCodeLength = sizeof(statusCode);
+        BOOL ret2 = pHttpQueryInfoA(hResult, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+                                    &statusCode, &dwStatusCodeLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(1). failed Error: %d\r\n", LastErr());
+            if (refURL != NULL)
+                FreeMem((HLOCAL)refURL);
+            return hResult;
+        }
+
+        if (statusCode == HTTP_STATUS_MOVED || statusCode == HTTP_STATUS_REDIRECT) {
+            DWORD dwBuffLength = 0;
+            ret2 = pHttpQueryInfoA(hResult, HTTP_QUERY_LOCATION, NULL, &dwBuffLength, NULL);
+            if (ret2 == FALSE && (LastErr() != ERROR_INSUFFICIENT_BUFFER || dwBuffLength == 0)) {
+                Log("HttpQueryInfoA(2). failed Error: %d\r\n", LastErr());
+                if (refURL != NULL)
+                    FreeMem((HLOCAL)refURL);
+                return hResult;
+            }
+
+            LPSTR buff = AllocMem(dwBuffLength + 1);
+
+            ret2 = pHttpQueryInfoA(hResult, HTTP_QUERY_LOCATION, buff, &dwBuffLength, NULL);
+            if (ret2 == FALSE) {
+                Log("HttpQueryInfoA(3). failed Error: %d\r\n", LastErr());
+                if (buff != NULL)
+                    FreeMem((HLOCAL)buff);
+                if (refURL != NULL)
+                    FreeMem((HLOCAL)refURL);
+                return hResult;
+            }
+
+            pInternetCloseHandle(hResult);
+            hResult = NULL;
+
+            hResult = InternetOpenUrlABypasSelfSignedCertificate(
+                hInternet, buff, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
+
+            if (buff != NULL)
+                FreeMem((HLOCAL)buff);
+        }
+    }
+
+    if (refURL != NULL)
+        FreeMem((HLOCAL)refURL);
+
     return hResult;
 }
 
+HINTERNET STDCALL InternetConnectAHook(HINTERNET hInternet, LPCSTR lpszServerName,
+                                       INTERNET_PORT nServerPort, LPCSTR lpszUserName,
+                                       LPCSTR lpszPassword, DWORD dwService, DWORD dwFlags,
+                                       DWORD_PTR dwContext) {
+
+    HINTERNET ret = pInternetConnectA(hInternet, lpszServerName, nServerPort, lpszUserName,
+                                      lpszPassword, dwService, dwFlags, dwContext);
+
+    if (ret != NULL)
+        createInetCtx(hInternet, ret, lpszServerName, nServerPort, lpszUserName, lpszPassword,
+                      dwService, dwFlags, dwContext, NULL, NULL);
+
+    return ret;
+}
+
+HINTERNET STDCALL HttpOpenRequestAHook(HINTERNET hConnect, LPCSTR lpszVerb, LPCSTR lpszObjectName,
+                                       LPCSTR lpszVersion, LPCSTR lpszReferrer,
+                                       LPCSTR *lplpszAcceptTypes, DWORD dwFlags,
+                                       DWORD_PTR dwContext) {
+
+    HINTERNET hReq = pHttpOpenRequestA(hConnect, lpszVerb, lpszObjectName, lpszVersion,
+                                       lpszReferrer, lplpszAcceptTypes, dwFlags, dwContext);
+
+    if (hReq != NULL) {
+        DWORD len = 0;
+        BOOL ret2 = pInternetQueryOptionA(hReq, INTERNET_OPTION_URL, NULL, &len);
+        if (ret2 == FALSE && LastErr() != ERROR_INSUFFICIENT_BUFFER) {
+            Log("InternetQueryOptionA(1) failed. Error: %d\r\n", LastErr());
+            return hReq;
+        }
+        if (len <= 0) {
+            Log("InternetQueryOptionA(1) returned the url length with the value 0. Error: %d\r\n",
+                LastErr());
+            return hReq;
+        }
+        LPSTR url = AllocMem(len);
+        ret2 = pInternetQueryOptionA(hReq, INTERNET_OPTION_URL, url, &len);
+        if (ret2 == FALSE) {
+            FreeMem((HLOCAL)url);
+            Log("InternetQueryOptionA(2) failed. Error: %d\r\n", LastErr());
+            return hReq;
+        }
+
+        LPCSTR newURL = RewriteURL(url);
+        if (newURL == NULL) {
+            Log("HttpOpenRequestA(%s) // (no rewrite rules matched)\r\n", url);
+            FreeMem((HLOCAL)url);
+            return hReq;
+        }
+
+        Log("HttpOpenRequestA(%s -> %s)\r\n", url, newURL);
+
+        FreeMem((HLOCAL)url);
+
+        URL_COMPONENTSA url_cpsa;
+        memset(&url_cpsa, 0, sizeof(URL_COMPONENTSA));
+        url_cpsa.dwStructSize = sizeof(URL_COMPONENTSA);
+        url_cpsa.dwSchemeLength = 10;
+        url_cpsa.dwHostNameLength = 512;
+        url_cpsa.dwUserNameLength = 256;
+        url_cpsa.dwPasswordLength = 256;
+        url_cpsa.dwUrlPathLength = 1024;
+        url_cpsa.dwExtraInfoLength = 2048;
+
+        if (pInternetCrackUrlA(newURL, lstrlenA(newURL), 0, &url_cpsa) == FALSE) {
+            FreeMem((HLOCAL)newURL);
+            Log("InternetCrackUrlA failed. Error: %d\r\n", LastErr());
+            return hReq;
+        }
+
+        LPSTR lpszHostName =
+            (url_cpsa.dwHostNameLength == 0u ? NULL : AllocMem(url_cpsa.dwHostNameLength + 1));
+        LPSTR lpszUserName =
+            (url_cpsa.dwUserNameLength == 0u ? NULL : AllocMem(url_cpsa.dwUserNameLength + 1));
+        LPSTR lpszPassword =
+            (url_cpsa.dwPasswordLength == 0u ? NULL : AllocMem(url_cpsa.dwPasswordLength + 1));
+
+        if (lpszHostName != NULL) {
+            memcpy(lpszHostName, url_cpsa.lpszHostName, url_cpsa.dwHostNameLength);
+            lpszHostName[url_cpsa.dwHostNameLength] = '\0';
+        }
+        if (lpszUserName != NULL) {
+            memcpy(lpszUserName, url_cpsa.lpszUserName, url_cpsa.dwUserNameLength);
+            lpszUserName[url_cpsa.dwUserNameLength] = '\0';
+        }
+        if (lpszPassword != NULL) {
+            memcpy(lpszPassword, url_cpsa.lpszPassword, url_cpsa.dwPasswordLength);
+            lpszPassword[url_cpsa.dwPasswordLength] = '\0';
+        }
+
+        internet_ctx *inet_ctx = findInetCtxByConnect(hConnect);
+
+        if (inet_ctx == NULL) {
+            FreeMem((HLOCAL)newURL);
+            if (lpszHostName != NULL)
+                FreeMem((HLOCAL)lpszHostName);
+            if (lpszUserName != NULL)
+                FreeMem((HLOCAL)lpszUserName);
+            if (lpszPassword != NULL)
+                FreeMem((HLOCAL)lpszPassword);
+            return hReq;
+        }
+
+        pInternetCloseHandle(hReq);
+        hReq = NULL;
+
+        inet_ctx->hNewConnect = pInternetConnectA(inet_ctx->hOpen, lpszHostName, url_cpsa.nPort,
+                                                  lpszUserName, lpszPassword, inet_ctx->dwService,
+                                                  inet_ctx->dwFlags, inet_ctx->dwContext);
+
+        if (lpszHostName != NULL)
+            FreeMem((HLOCAL)lpszHostName);
+        if (lpszUserName != NULL)
+            FreeMem((HLOCAL)lpszUserName);
+        if (lpszPassword != NULL)
+            FreeMem((HLOCAL)lpszPassword);
+
+        if (inet_ctx->hNewConnect == NULL) {
+            FreeMem((HLOCAL)newURL);
+            Log("InternetConnectA failed. Error: %d\r\n", LastErr());
+            return hReq;
+        }
+
+        LPCSTR lpszNewObjectName =
+            (newURL + url_cpsa.dwSchemeLength + 3 +
+             UserNameAndPasswordLength(url_cpsa.dwUserNameLength, url_cpsa.dwPasswordLength) +
+             url_cpsa.dwHostNameLength + PortLength(url_cpsa.nPort));
+
+        if (url_cpsa.nScheme == INTERNET_SCHEME_HTTPS)
+            dwFlags |= INTERNET_FLAG_SECURE;
+
+        if (Config.bBypassSelfSignedCertificate == TRUE)
+            dwFlags |=
+                INTERNET_FLAG_IGNORE_CERT_CN_INVALID | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+
+        hReq = pHttpOpenRequestA(inet_ctx->hNewConnect, lpszVerb, lpszNewObjectName, lpszVersion,
+                                 lpszReferrer, lplpszAcceptTypes, dwFlags, dwContext);
+
+        FreeMem((HLOCAL)newURL);
+
+        if (hReq == NULL) {
+            pInternetCloseHandle(inet_ctx->hNewConnect);
+            inet_ctx->hNewConnect = NULL;
+            Log("HttpOpenRequestA failed. Error: %d\r\n", LastErr());
+            return NULL;
+        }
+
+        if (Config.bBypassSelfSignedCertificate == TRUE) {
+            DWORD dwFlags2;
+            DWORD dwBuffLen = sizeof(dwFlags2);
+
+            ret2 =
+                pInternetQueryOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, &dwBuffLen);
+
+            if (ret2 == FALSE) {
+                Log("InternetQueryOptionA(3) failed. Error: %d\r\n", LastErr());
+                pInternetCloseHandle(hReq);
+                pInternetCloseHandle(inet_ctx->hNewConnect);
+                inet_ctx->hNewConnect = NULL;
+                return NULL;
+            }
+
+            dwFlags2 |= SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_WEAK_SIGNATURE |
+                        SECURITY_FLAG_IGNORE_WRONG_USAGE | SECURITY_FLAG_IGNORE_REVOCATION;
+
+            ret2 = pInternetSetOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2,
+                                       sizeof(dwFlags2));
+
+            if (ret2 == FALSE) {
+                Log("InternetSetOptionA failed. Error: %d\r\n", LastErr());
+                pInternetCloseHandle(hReq);
+                pInternetCloseHandle(inet_ctx->hNewConnect);
+                inet_ctx->hNewConnect = NULL;
+                return NULL;
+            }
+        }
+
+        inet_ctx->hRequest = hReq;
+        inet_ctx->rgpszAcceptTypes = lplpszAcceptTypes;
+
+        if (lpszVerb != NULL) {
+            int len = lstrlenA(lpszVerb);
+
+            inet_ctx->lpszMethod = AllocMem(len + 1);
+            memcpy(inet_ctx->lpszMethod, lpszVerb, len);
+            inet_ctx->lpszMethod[len] = '\0';
+        }
+    }
+
+    return hReq;
+}
+
+BOOL STDCALL HttpSendRequestACertificateInvalidRedirect(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                                        DWORD dwHeadersLength, LPVOID lpOptional,
+                                                        DWORD dwOptionalLength) {
+
+    LPSTR url = NULL;
+    BOOL ret2 = FALSE;
+
+    if (LastErr() == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION) {
+        DWORD statusCode = 0;
+        DWORD dwStatusCodeLength = sizeof(statusCode);
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+                               &statusCode, &dwStatusCodeLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(1). failed Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+
+        if (statusCode != HTTP_STATUS_MOVED && statusCode != HTTP_STATUS_REDIRECT)
+            return FALSE;
+
+        DWORD dwBuffLength = 0;
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_LOCATION, NULL, &dwBuffLength, NULL);
+        if (ret2 == FALSE && (LastErr() != ERROR_INSUFFICIENT_BUFFER || dwBuffLength == 0)) {
+            Log("HttpQueryInfoA(2). failed Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+
+        url = AllocMem(dwBuffLength + 1);
+
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_LOCATION, url, &dwBuffLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(3). failed Error: %d\r\n", LastErr());
+            if (url != NULL)
+                FreeMem((HLOCAL)url);
+            return FALSE;
+        }
+    } else {
+        DWORD len = 0;
+        ret2 = pInternetQueryOptionA(hRequest, INTERNET_OPTION_URL, NULL, &len);
+        if (ret2 == FALSE && LastErr() != ERROR_INSUFFICIENT_BUFFER) {
+            Log("InternetQueryOptionA(1) failed. Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+        if (len <= 0) {
+            Log("InternetQueryOptionA(1) returned the url length with the value 0. Error: %d\r\n",
+                LastErr());
+            return FALSE;
+        }
+        url = AllocMem(len);
+        ret2 = pInternetQueryOptionA(hRequest, INTERNET_OPTION_URL, url, &len);
+        if (ret2 == FALSE) {
+            FreeMem((HLOCAL)url);
+            Log("InternetQueryOptionA(2) failed. Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+    }
+
+    internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
+
+    if (inet_ctx == NULL) {
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    URL_COMPONENTSA url_cpsa;
+    memset(&url_cpsa, 0, sizeof(URL_COMPONENTSA));
+    url_cpsa.dwStructSize = sizeof(URL_COMPONENTSA);
+    url_cpsa.dwSchemeLength = 10;
+    url_cpsa.dwHostNameLength = 512;
+    url_cpsa.dwUserNameLength = 256;
+    url_cpsa.dwPasswordLength = 256;
+
+    if (pInternetCrackUrlA(url, lstrlenA(url), 0, &url_cpsa) == FALSE) {
+        Log("InternetCrackUrlA failed. Error: %d\r\n", LastErr());
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    LPSTR lpszHostName =
+        (url_cpsa.dwHostNameLength == 0u ? NULL : AllocMem(url_cpsa.dwHostNameLength + 1));
+
+    if (lpszHostName != NULL) {
+        memcpy(lpszHostName, url_cpsa.lpszHostName, url_cpsa.dwHostNameLength);
+        lpszHostName[url_cpsa.dwHostNameLength] = '\0';
+    }
+
+    if (inet_ctx->hRequest != NULL) {
+        pInternetCloseHandle(inet_ctx->hRequest);
+        inet_ctx->hRequest = NULL;
+    }
+    if (inet_ctx->hNewConnect != NULL) {
+        pInternetCloseHandle(inet_ctx->hNewConnect);
+        inet_ctx->hNewConnect = NULL;
+    }
+
+    HINTERNET hConnect =
+        pInternetConnectA(inet_ctx->hOpen, lpszHostName, url_cpsa.nPort, NULL, NULL,
+                          INTERNET_SERVICE_HTTP, inet_ctx->dwFlags, inet_ctx->dwContext);
+
+    if (lpszHostName != NULL)
+        FreeMem((HLOCAL)lpszHostName);
+
+    if (hConnect == NULL) {
+        Log("InternetConnectA. failed Error: %d\r\n", LastErr());
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    DWORD newFlags = inet_ctx->dwFlags;
+
+    if (url_cpsa.nScheme == INTERNET_SCHEME_HTTPS)
+        newFlags |= INTERNET_FLAG_SECURE;
+
+    if (Config.bBypassSelfSignedCertificate == TRUE)
+        newFlags |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+
+    LPCSTR lpszNewObjectName =
+        (url + url_cpsa.dwSchemeLength + 3 +
+         UserNameAndPasswordLength(url_cpsa.dwUserNameLength, url_cpsa.dwPasswordLength) +
+         url_cpsa.dwHostNameLength + PortLength(url_cpsa.nPort));
+
+    HINTERNET hReq =
+        pHttpOpenRequestA(hConnect, inet_ctx->lpszMethod, lpszNewObjectName, HTTP_VERSIONA, NULL,
+                          inet_ctx->rgpszAcceptTypes, newFlags, inet_ctx->dwContext);
+
+    if (url != NULL)
+        FreeMem((HLOCAL)url);
+
+    if (hReq == NULL) {
+        Log("HttpEndRequestACertificateInvalidRedirect->HttpOpenRequestA. failed Error: %d\r\n",
+            LastErr());
+        pInternetCloseHandle(hConnect);
+        return FALSE;
+    }
+
+	if (Config.bBypassSelfSignedCertificate == TRUE) {
+		DWORD dwFlags2;
+		DWORD dwBuffLen = sizeof(dwFlags2);
+
+		ret2 = pInternetQueryOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, &dwBuffLen);
+
+		if (ret2 == FALSE) {
+			Log("InternetQueryOptionA failed. Error: %d\r\n", LastErr());
+			pInternetCloseHandle(hReq);
+			pInternetCloseHandle(hConnect);
+			return FALSE;
+		}
+
+		dwFlags2 |= SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_WEAK_SIGNATURE |
+					SECURITY_FLAG_IGNORE_WRONG_USAGE | SECURITY_FLAG_IGNORE_REVOCATION;
+
+		ret2 = pInternetSetOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, sizeof(dwFlags2));
+
+		if (ret2 == FALSE) {
+			Log("InternetSetOptionA failed. Error: %d\r\n", LastErr());
+			pInternetCloseHandle(hReq);
+			pInternetCloseHandle(hConnect);
+			return FALSE;
+		}
+	}
+
+    for (DWORD i = 0u; i < inet_ctx->nHeaders; i++) {
+
+        ret2 = pHttpAddRequestHeadersA(hReq, inet_ctx->vHeaders[i].lpszHeaders,
+                                       inet_ctx->vHeaders[i].dwHeaderLength,
+                                       inet_ctx->vHeaders[i].dwModifiers);
+
+        if (ret2 == FALSE) {
+            Log("HttpAddRequestHeadersA failed. Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            return FALSE;
+        }
+    }
+
+    ret2 = pHttpSendRequestA(hReq, lpszHeaders, dwHeadersLength, lpOptional, dwOptionalLength);
+
+    if (ret2 == FALSE) {
+        DWORD error = LastErr();
+
+        if (error == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION ||
+            (Config.bBypassSelfSignedCertificate == TRUE &&
+             (error == ERROR_INTERNET_SEC_CERT_DATE_INVALID ||
+              error == ERROR_INTERNET_SEC_CERT_CN_INVALID || error == ERROR_INTERNET_INVALID_CA))) {
+            inet_ctx->hRequest = hReq;
+            ret2 = HttpSendRequestACertificateInvalidRedirect(hReq, lpszHeaders, dwHeadersLength,
+                                                              lpOptional, dwOptionalLength);
+        } else
+            Log("HttpSendRequestA(2). failed Error: %d\r\n", error);
+
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        return ret2;
+    }
+
+    return TRUE;
+}
+
+BOOL STDCALL HttpSendRequestAHook(HINTERNET hRequest, LPCSTR lpszHeaders, DWORD dwHeadersLength,
+                                  LPVOID lpOptional, DWORD dwOptionalLength) {
+
+    BOOL bRet =
+        pHttpSendRequestA(hRequest, lpszHeaders, dwHeadersLength, lpOptional, dwOptionalLength);
+
+    if (bRet == FALSE) {
+        DWORD error = LastErr();
+
+        if (error == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION ||
+            (Config.bBypassSelfSignedCertificate == TRUE &&
+             (error == ERROR_INTERNET_SEC_CERT_DATE_INVALID ||
+              error == ERROR_INTERNET_SEC_CERT_CN_INVALID || error == ERROR_INTERNET_INVALID_CA))) {
+
+            bRet = HttpSendRequestACertificateInvalidRedirect(
+                hRequest, lpszHeaders, dwHeadersLength, lpOptional, dwOptionalLength);
+        }
+    }
+
+    return bRet;
+}
+
+BOOL STDCALL HttpSendRequestExAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersIn,
+                                    LPINTERNET_BUFFERSA lpBuffersOut, DWORD dwFlags,
+                                    DWORD_PTR dwContext) {
+
+    BOOL bRet = pHttpSendRequestExA(hRequest, lpBuffersIn, lpBuffersOut, dwFlags, dwContext);
+
+    if (bRet == TRUE) {
+
+        internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
+
+        if (inet_ctx == NULL)
+            return bRet;
+
+        inet_ctx->lpBuffersIn = lpBuffersIn;
+    }
+
+    return bRet;
+}
+
+BOOL STDCALL HttpEndRequestACertificateInvalidRedirect(HINTERNET hRequest,
+                                                       LPINTERNET_BUFFERSA lpBuffersOut,
+                                                       DWORD dwFlags, DWORD_PTR dwContext) {
+
+    LPSTR url = NULL;
+    BOOL ret2 = FALSE;
+
+    if (LastErr() == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION) {
+        DWORD statusCode = 0;
+        DWORD dwStatusCodeLength = sizeof(statusCode);
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+                               &statusCode, &dwStatusCodeLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(1). failed Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+
+        if (statusCode != HTTP_STATUS_MOVED && statusCode != HTTP_STATUS_REDIRECT)
+            return FALSE;
+
+        DWORD dwBuffLength = 0;
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_LOCATION, NULL, &dwBuffLength, NULL);
+        if (ret2 == FALSE && (LastErr() != ERROR_INSUFFICIENT_BUFFER || dwBuffLength == 0)) {
+            Log("HttpQueryInfoA(2). failed Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+
+        url = AllocMem(dwBuffLength + 1);
+
+        ret2 = pHttpQueryInfoA(hRequest, HTTP_QUERY_LOCATION, url, &dwBuffLength, NULL);
+        if (ret2 == FALSE) {
+            Log("HttpQueryInfoA(3). failed Error: %d\r\n", LastErr());
+            if (url != NULL)
+                FreeMem((HLOCAL)url);
+            return FALSE;
+        }
+    } else {
+        DWORD len = 0;
+        ret2 = pInternetQueryOptionA(hRequest, INTERNET_OPTION_URL, NULL, &len);
+        if (ret2 == FALSE && LastErr() != ERROR_INSUFFICIENT_BUFFER) {
+            Log("InternetQueryOptionA(1) failed. Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+        if (len <= 0) {
+            Log("InternetQueryOptionA(1) returned the url length with the value 0. Error: %d\r\n",
+                LastErr());
+            return FALSE;
+        }
+        url = AllocMem(len);
+        ret2 = pInternetQueryOptionA(hRequest, INTERNET_OPTION_URL, url, &len);
+        if (ret2 == FALSE) {
+            FreeMem((HLOCAL)url);
+            Log("InternetQueryOptionA(2) failed. Error: %d\r\n", LastErr());
+            return FALSE;
+        }
+    }
+
+    internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
+
+    if (inet_ctx == NULL) {
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    URL_COMPONENTSA url_cpsa;
+    memset(&url_cpsa, 0, sizeof(URL_COMPONENTSA));
+    url_cpsa.dwStructSize = sizeof(URL_COMPONENTSA);
+    url_cpsa.dwSchemeLength = 10;
+    url_cpsa.dwHostNameLength = 512;
+    url_cpsa.dwUserNameLength = 256;
+    url_cpsa.dwPasswordLength = 256;
+
+    if (pInternetCrackUrlA(url, lstrlenA(url), 0, &url_cpsa) == FALSE) {
+        Log("InternetCrackUrlA failed. Error: %d\r\n", LastErr());
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    LPSTR lpszHostName =
+        (url_cpsa.dwHostNameLength == 0u ? NULL : AllocMem(url_cpsa.dwHostNameLength + 1));
+
+    if (lpszHostName != NULL) {
+        memcpy(lpszHostName, url_cpsa.lpszHostName, url_cpsa.dwHostNameLength);
+        lpszHostName[url_cpsa.dwHostNameLength] = '\0';
+    }
+
+    if (inet_ctx->hRequest != NULL) {
+        pInternetCloseHandle(inet_ctx->hRequest);
+        inet_ctx->hRequest = NULL;
+    }
+    if (inet_ctx->hNewConnect != NULL) {
+        pInternetCloseHandle(inet_ctx->hNewConnect);
+        inet_ctx->hNewConnect = NULL;
+    }
+
+    HINTERNET hConnect = pInternetConnectA(inet_ctx->hOpen, lpszHostName, url_cpsa.nPort, NULL,
+                                           NULL, INTERNET_SERVICE_HTTP, dwFlags, dwContext);
+
+    if (lpszHostName != NULL)
+        FreeMem((HLOCAL)lpszHostName);
+
+    if (hConnect == NULL) {
+        Log("InternetConnectA. failed Error: %d\r\n", LastErr());
+        if (url != NULL)
+            FreeMem((HLOCAL)url);
+        return FALSE;
+    }
+
+    DWORD newFlags = dwFlags;
+
+    if (url_cpsa.nScheme == INTERNET_SCHEME_HTTPS)
+        newFlags |= INTERNET_FLAG_SECURE;
+
+	if (Config.bBypassSelfSignedCertificate == TRUE)
+		newFlags |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+
+    LPCSTR lpszNewObjectName =
+        (url + url_cpsa.dwSchemeLength + 3 +
+         UserNameAndPasswordLength(url_cpsa.dwUserNameLength, url_cpsa.dwPasswordLength) +
+         url_cpsa.dwHostNameLength + PortLength(url_cpsa.nPort));
+
+    HINTERNET hReq =
+        pHttpOpenRequestA(hConnect, inet_ctx->lpszMethod, lpszNewObjectName, HTTP_VERSIONA, NULL,
+                          inet_ctx->rgpszAcceptTypes, newFlags, dwContext);
+
+    if (url != NULL)
+        FreeMem((HLOCAL)url);
+
+    if (hReq == NULL) {
+        Log("HttpEndRequestACertificateInvalidRedirect->HttpOpenRequestA. failed Error: %d\r\n",
+            LastErr());
+        pInternetCloseHandle(hConnect);
+        return FALSE;
+    }
+
+	if (Config.bBypassSelfSignedCertificate == TRUE) {
+		DWORD dwFlags2;
+		DWORD dwBuffLen = sizeof(dwFlags2);
+
+		ret2 = pInternetQueryOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, &dwBuffLen);
+
+		if (ret2 == FALSE) {
+			Log("InternetQueryOptionA failed. Error: %d\r\n", LastErr());
+			pInternetCloseHandle(hReq);
+			pInternetCloseHandle(hConnect);
+			return FALSE;
+		}
+
+		dwFlags2 |= SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_WEAK_SIGNATURE |
+					SECURITY_FLAG_IGNORE_WRONG_USAGE | SECURITY_FLAG_IGNORE_REVOCATION;
+
+		ret2 = pInternetSetOptionA(hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags2, sizeof(dwFlags2));
+
+		if (ret2 == FALSE) {
+			Log("InternetSetOptionA failed. Error: %d\r\n", LastErr());
+			pInternetCloseHandle(hReq);
+			pInternetCloseHandle(hConnect);
+			return FALSE;
+		}
+	}
+
+    for (DWORD i = 0u; i < inet_ctx->nHeaders; i++) {
+
+        ret2 = pHttpAddRequestHeadersA(hReq, inet_ctx->vHeaders[i].lpszHeaders,
+                                       inet_ctx->vHeaders[i].dwHeaderLength,
+                                       inet_ctx->vHeaders[i].dwModifiers);
+
+        if (ret2 == FALSE) {
+            Log("HttpAddRequestHeadersA failed. Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            return FALSE;
+        }
+    }
+
+    ret2 = pHttpSendRequestExA(hReq, inet_ctx->lpBuffersIn, NULL, dwFlags, inet_ctx->dwContext);
+    if (ret2 == FALSE) {
+        Log("HttpSendRequestExA. failed Error: %d\r\n", LastErr());
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        return FALSE;
+    }
+
+    if (inet_ctx->lpFileBuffer != NULL && inet_ctx->dwNumberOfBytesToWrite > 0) {
+        DWORD dwNumbetOfBytesWritten = 0;
+
+        ret2 = pInternetWriteFile(hReq, inet_ctx->lpFileBuffer, inet_ctx->dwNumberOfBytesToWrite,
+                                  &dwNumbetOfBytesWritten);
+
+        if (ret2 == FALSE && LastErr() != ERROR_INSUFFICIENT_BUFFER) {
+            Log("InternetWriteFile. failed Error: %d\r\n", LastErr());
+            pInternetCloseHandle(hReq);
+            pInternetCloseHandle(hConnect);
+            return FALSE;
+        }
+    }
+
+    ret2 = pHttpEndRequestA(hReq, lpBuffersOut, dwFlags, dwContext);
+
+    if (ret2 == FALSE) {
+        DWORD error = LastErr();
+
+        if (error == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION ||
+            (Config.bBypassSelfSignedCertificate == TRUE &&
+             (error == ERROR_INTERNET_SEC_CERT_DATE_INVALID ||
+              error == ERROR_INTERNET_SEC_CERT_CN_INVALID || error == ERROR_INTERNET_INVALID_CA))) {
+            inet_ctx->hRequest = hReq;
+            ret2 =
+                HttpEndRequestACertificateInvalidRedirect(hReq, lpBuffersOut, dwFlags, dwContext);
+        } else
+            Log("HttpEndRequestA(2). failed Error: %d\r\n", error);
+
+        pInternetCloseHandle(hReq);
+        pInternetCloseHandle(hConnect);
+        return ret2;
+    }
+
+    return TRUE;
+}
+
+BOOL STDCALL HttpEndRequestAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersOut,
+                                 DWORD dwFlags, DWORD_PTR dwContext) {
+
+    BOOL bRet = pHttpEndRequestA(hRequest, lpBuffersOut, dwFlags, dwContext);
+
+    if (bRet == FALSE) {
+        DWORD error = LastErr();
+
+        if (error == ERROR_HTTP_REDIRECT_NEEDS_CONFIRMATION ||
+            (Config.bBypassSelfSignedCertificate == TRUE &&
+             (error == ERROR_INTERNET_SEC_CERT_DATE_INVALID ||
+              error == ERROR_INTERNET_SEC_CERT_CN_INVALID || error == ERROR_INTERNET_INVALID_CA))) {
+
+            bRet = HttpEndRequestACertificateInvalidRedirect(hRequest, lpBuffersOut, dwFlags,
+                                                             dwContext);
+        }
+    }
+
+    return bRet;
+}
+
+BOOL STDCALL HttpAddRequestHeadersAHook(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                        DWORD dwHeadersLength, DWORD dwModifiers) {
+
+    BOOL bRet = pHttpAddRequestHeadersA(hRequest, lpszHeaders, dwHeadersLength, dwModifiers);
+
+    if (bRet == TRUE) {
+
+        internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
+
+        if (inet_ctx == NULL || inet_ctx->nHeaders >= MAX_HTTP_HEADER)
+            return bRet;
+
+        http_header *pHeader = &inet_ctx->vHeaders[inet_ctx->nHeaders++];
+
+        pHeader->lpszHeaders = lpszHeaders;
+        pHeader->dwHeaderLength = dwHeadersLength;
+        pHeader->dwModifiers = dwModifiers;
+    }
+
+    return bRet;
+}
+
+BOOL STDCALL InternetWriteFileHook(HINTERNET hFile, LPCVOID lpBuffer, DWORD dwNumberOfBytesToWrite,
+                                   LPDWORD lpdwNumberOfBytesWritten) {
+
+    BOOL bRet =
+        pInternetWriteFile(hFile, lpBuffer, dwNumberOfBytesToWrite, lpdwNumberOfBytesWritten);
+
+    if (bRet == TRUE || LastErr() == ERROR_INSUFFICIENT_BUFFER) {
+
+        internet_ctx *inet_ctx = findInetCtxByRequest(hFile);
+
+        if (inet_ctx == NULL ||
+            (inet_ctx->lpFileBuffer != NULL && inet_ctx->dwNumberOfBytesToWrite > 0u))
+            return bRet;
+
+        inet_ctx->lpFileBuffer = lpBuffer;
+        inet_ctx->dwNumberOfBytesToWrite = dwNumberOfBytesToWrite;
+    }
+
+    return bRet;
+}
+
+BOOL STDCALL InternetCloseHandleHook(HINTERNET hInternet) {
+
+    internet_ctx *inet_ctx = findInetCtxByConnect(hInternet);
+
+    if (inet_ctx != NULL) {
+
+        if (inet_ctx->hNewConnect != NULL)
+            pInternetCloseHandle(inet_ctx->hNewConnect);
+
+        removeInetCtx(inet_ctx);
+    }
+
+    return pInternetCloseHandle(hInternet);
+}
+
 VOID InitNetRedirHook() {
+    memset(&g_inet_ctx, 0, sizeof(g_inet_ctx));
+
     hWinINet = LoadLib("wininet");
+    pInternetQueryOptionA = GetProc(hWinINet, "InternetQueryOptionA");
+    pInternetSetOptionA = GetProc(hWinINet, "InternetSetOptionA");
+    pInternetCrackUrlA = GetProc(hWinINet, "InternetCrackUrlA");
+    pHttpQueryInfoA = GetProc(hWinINet, "HttpQueryInfoA");
     pInternetOpenUrlA = HookProc(hWinINet, "InternetOpenUrlA", InternetOpenUrlAHook);
+    pInternetConnectA = HookProc(hWinINet, "InternetConnectA", InternetConnectAHook);
+    pHttpOpenRequestA = HookProc(hWinINet, "HttpOpenRequestA", HttpOpenRequestAHook);
+    pHttpSendRequestA = HookProc(hWinINet, "HttpSendRequestA", HttpSendRequestAHook);
+    pHttpEndRequestA = HookProc(hWinINet, "HttpEndRequestA", HttpEndRequestAHook);
+    pHttpAddRequestHeadersA =
+        HookProc(hWinINet, "HttpAddRequestHeadersA", HttpAddRequestHeadersAHook);
+    pHttpSendRequestExA = HookProc(hWinINet, "HttpSendRequestExA", HttpSendRequestExAHook);
+    pInternetCloseHandle = HookProc(hWinINet, "InternetCloseHandle", InternetCloseHandleHook);
+    pInternetWriteFile = HookProc(hWinINet, "InternetWriteFile", InternetWriteFileHook);
 }


### PR DESCRIPTION
Adds GG Patch for:
TH S2 312b;
TH S2 321a.

Fixed CreateProccessAHook that was creating false Handle for processes other than GameGuard.des.

Added the option in the rugburn.json config file to ignore invalid certificates in WinInet since PangYa does not handle these errors.
Ex:
....
"BypassSelfSignedCertificate": "TRUE"
....

The WebBrowser is Internet Explorer and it handles these errors so this option is only for WinInet.

In WinInet there is an InternetErrorDlg function to request user permission, but I couldn't make it work even passing the HWND with GetActiveWinow() and with specific flags, it doesn't show the Dlg and returns ERROR_CANCELED, so I decided to put the BypassSelfSignedCertificate option to ignore certificate errors and POST redirection errors that require user confirmation. I didn't make an option, I set it to ignore this error and redirect.

With these implementations, all PangYa URLs will go through ReWriteURL from both WinInet and WebBrowser.

I compiled and tested with MSVC and Cygwin64->MinGW32:
ProjectG.exe S9 TH 826c;
ProjectG.exe S1 BR 216;
ProjectG.exe S2 BR 305a;
update_br.exe S2 BR 305a;
PangFBI.exe BR 305a.

All worked without problems.

"PangFBI.exe" reports logs to the Pangya http server, it is present in old Pangya seasons, in new seasons it is inside ProjectG.exe.

To execute ijl15.dll in "update_br.exe" and "PangFBI.exe" I injected the dll ijl15.dll with the program "CFF_Explorer":
I opened the .exe, clicked on "Import Adder" in the list and clicked on the "Add" button, selected ijl15.dll, clicked ok then selected ijlGetLibVersion, clicked on the "Import By Ordinal" button then clicked on "Rebuild Import Table" after that I clicked on "Rebuilder" in the list, clicked on the "Bind Import Table" checkbox then clicked on the "Rebuild" button then clicked on the save button.