### PR TITLE
Fix missing static declarations

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -37,7 +37,7 @@ const char ExampleRugburnConfig[] =
     "  ]\r\n"
     "}\r\n";
 
-void ReadJsonUrlRewriteRuleMap(LPSTR *json, LPCSTR key) {
+static void ReadJsonUrlRewriteRuleMap(LPSTR *json, LPCSTR key) {
     LPCSTR value = JsonReadString(json);
 
     if (Config.NumUrlRewriteRules == MAXURLREWRITES) {
@@ -49,7 +49,7 @@ void ReadJsonUrlRewriteRuleMap(LPSTR *json, LPCSTR key) {
     Config.NumUrlRewriteRules++;
 }
 
-void ReadJsonPortRewriteRuleMap(LPSTR *json, LPCSTR key) {
+static void ReadJsonPortRewriteRuleMap(LPSTR *json, LPCSTR key) {
     if (!strcmp(key, "FromPort")) {
         Config.PortRewriteRules[Config.NumPortRewriteRules].fromport = JsonReadInteger(json);
     } else if (!strcmp(key, "ToPort")) {
@@ -61,7 +61,7 @@ void ReadJsonPortRewriteRuleMap(LPSTR *json, LPCSTR key) {
     }
 }
 
-void ReadJsonPortRewriteRuleArray(LPSTR *json) {
+static void ReadJsonPortRewriteRuleArray(LPSTR *json) {
     if (Config.NumPortRewriteRules == MAXURLREWRITES) {
         FatalError("Reached maximum number of URL rewrite rules!");
     }
@@ -70,7 +70,7 @@ void ReadJsonPortRewriteRuleArray(LPSTR *json) {
     Config.NumPortRewriteRules++;
 }
 
-void ReadJsonPatchAddressMap(LPSTR *json, LPCSTR key) {
+static void ReadJsonPatchAddressMap(LPSTR *json, LPCSTR key) {
     LPCSTR value = JsonReadString(json);
 
     if (Config.NumPatchAddress == MAXPATCHADDRESS) {
@@ -83,7 +83,7 @@ void ReadJsonPatchAddressMap(LPSTR *json, LPCSTR key) {
     Config.NumPatchAddress++;
 }
 
-void ReadJsonBypassSelfSignedCertificate(LPSTR *json, LPCSTR key) {
+static void ReadJsonBypassSelfSignedCertificate(LPSTR *json, LPCSTR key) {
     LPCSTR value = JsonReadString(json);
 
     Config.bBypassSelfSignedCertificate = FALSE;
@@ -95,7 +95,7 @@ void ReadJsonBypassSelfSignedCertificate(LPSTR *json, LPCSTR key) {
         Config.bBypassSelfSignedCertificate = TRUE;
 }
 
-void ReadJsonConfigMap(LPSTR *json, LPCSTR key) {
+static void ReadJsonConfigMap(LPSTR *json, LPCSTR key) {
     if (!strcmp(key, "UrlRewrites")) {
         JsonReadMap(json, ReadJsonUrlRewriteRuleMap);
     } else if (!strcmp(key, "PortRewrites")) {

--- a/src/exe/test/main.c
+++ b/src/exe/test/main.c
@@ -78,11 +78,11 @@ typedef struct _DISPATCH_TESTCASE {
     PFNDISPATCHTESTPROC proc;
 } DISPATCH_TESTCASE;
 
-void STDCALL DispatchTest(const DISPATCH_TESTCASE *_this, DWORD testnum) {
+static void STDCALL DispatchTest(const DISPATCH_TESTCASE *_this, DWORD testnum) {
     ConsoleLog("ok %d - %s\r\n", testnum, _this->name);
 }
 
-void STDCALL DispatchThroughThiscallTest(const DISPATCH_TESTCASE *_this, DWORD testnum) {
+static void STDCALL DispatchThroughThiscallTest(const DISPATCH_TESTCASE *_this, DWORD testnum) {
     PFNDISPATCHTESTPROC pfnDispatchProc =
         (PFNDISPATCHTESTPROC)BuildStdcallToThiscallThunk(BuildThiscallToStdcallThunk(DispatchTest));
     pfnDispatchProc(_this, testnum);
@@ -101,7 +101,7 @@ const LPCSTR ld_tests[] = {
     "ff259017f476",
 };
 
-BOOL ijl15_crash_test() {
+static BOOL ijl15_crash_test() {
     JPEG_CORE_PROPERTIES jcp;
     DWORD dwWholeImageSize, dwJPGSizeBytes;
     PVOID pJPGBytes;

--- a/src/hooks/comctl32/dynamic_patch.c
+++ b/src/hooks/comctl32/dynamic_patch.c
@@ -30,7 +30,7 @@ static PFNGETSTARTUPINFOWPROC pGetStartupInfoW = NULL;
 
 #define GETRETURNADDRESS(_FirstParameter) *(((DWORD *)&(_FirstParameter)) - 1)
 
-BOOL compare_virtual_memory(DWORD _dwAddress, DWORD _value) {
+static BOOL compare_virtual_memory(DWORD _dwAddress, DWORD _value) {
     MEMORY_BASIC_INFORMATION mbi;
 
     if (VirtualQuery((void *)_dwAddress, &mbi, sizeof(mbi)) == 0) {
@@ -50,7 +50,7 @@ BOOL compare_virtual_memory(DWORD _dwAddress, DWORD _value) {
     return TRUE;
 }
 
-BOOL isModuleAllocationBase(DWORD _dwAddress) {
+static BOOL isModuleAllocationBase(DWORD _dwAddress) {
     MEMORY_BASIC_INFORMATION mbi;
 
     if (VirtualQuery((void *)_dwAddress, &mbi, sizeof(mbi)) == 0) {
@@ -74,7 +74,7 @@ BOOL isModuleAllocationBase(DWORD _dwAddress) {
 /**
  * Implements the GameGuard patches for Pangya US.
  */
-void PatchGG_US() {
+static void PatchGG_US() {
     if (compare_virtual_memory(0x00A495E0, 0x8F143D83)) {
         Patch((LPVOID)0x00A495E0, "\xC3\x90\x90\x90\x90\x90\x90", 7);
         Patch((LPVOID)0x00A49670, "\xC3\x90\x90\x90\x90\x90\x90", 7);
@@ -150,7 +150,7 @@ void PatchGG_US() {
 /**
  * Implements the GameGuard patches for Pangya JP.
  */
-void PatchGG_JP() {
+static void PatchGG_JP() {
     if (compare_virtual_memory(0x00A5CD10, 0x1BA43D83)) {
         Patch((LPVOID)0x00A5CD10, "\xC3\x90\x90\x90\x90\x90\x90", 7);
         Patch((LPVOID)0x00A5CDA0, "\xC3\x90\x90\x90\x90\x90\x90", 7);
@@ -194,7 +194,7 @@ void PatchGG_JP() {
     }
 }
 
-void PatchGG_TW() {
+static void PatchGG_TW() {
     if (compare_virtual_memory(0x00643743, 0xFF6B98E8)) {
         Patch((LPVOID)0x00643743, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (TW S2 3.00a)\r\n");
@@ -204,14 +204,14 @@ void PatchGG_TW() {
     }
 }
 
-void PatchHS_ID() {
+static void PatchHS_ID() {
     if (compare_virtual_memory(0x005FC66D, 0xFF071EE8)) {
         Patch((LPVOID)0x005FC66D, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched HSHIELD check routines (INA S1 2.12a)\r\n");
     }
 }
 
-void PatchHS_BR() {
+static void PatchHS_BR() {
     if (compare_virtual_memory(0x005FE093, 0xFF8858E8)) {
         Patch((LPVOID)0x005FE093, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched HSHIELD check routines (BR S1 2.14a)\r\n");
@@ -239,7 +239,7 @@ void PatchHS_BR() {
     }
 }
 
-void PatchGG_KR() {
+static void PatchGG_KR() {
     if (compare_virtual_memory(0x00634EAD, 0xFF178EE8)) {
         Patch((LPVOID)0x00634EAD, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (KR S2 3.26a)\r\n");
@@ -252,7 +252,7 @@ void PatchGG_KR() {
     }
 }
 
-void PatchGG_TH() {
+static void PatchGG_TH() {
     if (compare_virtual_memory(0x005F678A, 0xFF5B21E8)) {
         Patch((LPVOID)0x005F678A, "\xB8\x01\x00\x00\x00", 5);
         Log("Patched GG check routines (TH S1 217)\r\n");
@@ -280,7 +280,7 @@ void PatchGG_TH() {
     }
 }
 
-void PatchGG_SEA() {
+static void PatchGG_SEA() {
     if (compare_virtual_memory(0x00611CF8, 0xFF86D3E8)) {
         Patch((LPVOID)0x00611CF8, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (SEA S1 2.16a)\r\n");
@@ -290,7 +290,7 @@ void PatchGG_SEA() {
     }
 }
 
-void PatchGG_EU() {
+static void PatchGG_EU() {
     if (compare_virtual_memory(0x006160D1, 0xFF161AE8)) {
         Patch((LPVOID)0x006160D1, "\xE9\x00\x00\x00\x00", 5);
         Log("Patched GG check routines (EU S2 3.01a)\r\n");
@@ -303,7 +303,7 @@ void PatchGG_EU() {
     }
 }
 
-void oneExec_PatchDynamicAndGG() {
+static void oneExec_PatchDynamicAndGG() {
     static int one = 0;
     PANGYAVER pangyaVersion;
 
@@ -353,7 +353,7 @@ void oneExec_PatchDynamicAndGG() {
     PatchAddress();
 }
 
-BOOL STDCALL InitCommonControlsExHook(const INITCOMMONCONTROLSEX *picce) {
+static BOOL STDCALL InitCommonControlsExHook(const INITCOMMONCONTROLSEX *picce) {
     BOOL ret = pInitCommonControlsEx(picce);
 
     oneExec_PatchDynamicAndGG();
@@ -361,14 +361,14 @@ BOOL STDCALL InitCommonControlsExHook(const INITCOMMONCONTROLSEX *picce) {
     return ret;
 }
 
-VOID STDCALL GetStartupInfoAHook(LPSTARTUPINFOA lpStartupInfo) {
+static VOID STDCALL GetStartupInfoAHook(LPSTARTUPINFOA lpStartupInfo) {
     pGetStartupInfoA(lpStartupInfo);
 
     if (isModuleAllocationBase(GETRETURNADDRESS(lpStartupInfo)))
         oneExec_PatchDynamicAndGG();
 }
 
-VOID STDCALL GetStartupInfoWHook(LPSTARTUPINFOW lpStartupInfo) {
+static VOID STDCALL GetStartupInfoWHook(LPSTARTUPINFOW lpStartupInfo) {
     pGetStartupInfoW(lpStartupInfo);
 
     if (isModuleAllocationBase(GETRETURNADDRESS(lpStartupInfo)))

--- a/src/hooks/msvcr100/msvcr100.c
+++ b/src/hooks/msvcr100/msvcr100.c
@@ -24,9 +24,9 @@ static HMODULE hMsvcrModule = NULL;
 static STRICMPFNPTR pStricmp = NULL;
 static SETLOCALEFNPTR pSetLocale = NULL;
 
-int lower(int c) { return (c >= 'A' && c <= 'Z') ? c + 'a' - 'A' : c; }
+static int lower(int c) { return (c >= 'A' && c <= 'Z') ? c + 'a' - 'A' : c; }
 
-int __cdecl StricmpHook(const char *s1, const char *s2) {
+static int __cdecl StricmpHook(const char *s1, const char *s2) {
     int result = 0;
     if (!s1 || !s2)
         return 0x7fffffff;
@@ -39,7 +39,7 @@ int __cdecl StricmpHook(const char *s1, const char *s2) {
     return result;
 }
 
-VOID InitMsvcr100Hook() {
+static VOID InitMsvcr100Hook() {
     const char *oldlocale;
     int result;
 
@@ -72,7 +72,7 @@ VOID InitMsvcr100Hook() {
     }
 }
 
-VOID InitMsvcr71Hook() {
+static VOID InitMsvcr71Hook() {
     const char *oldlocale;
     int result;
 

--- a/src/hooks/ole32/web_browser.c
+++ b/src/hooks/ole32/web_browser.c
@@ -24,7 +24,7 @@ const IID kIID_MicrosoftWebBrowser = {
 const IID kIID_IWebBrowser2 = {
     0xD30C1661, 0xCDAF, 0x11D0, {0x8A, 0x3E, 0, 0xC0, 0x4F, 0xC9, 0xE2, 0x6E}};
 
-BSTR RewriteURLW(BSTR urlw) {
+static BSTR RewriteURLW(BSTR urlw) {
 
     int len_urlw = lstrlenW(urlw);
     int len = WideCharToMultiByte(CP_ACP, 0, urlw, len_urlw, NULL, 0, NULL, NULL);
@@ -57,9 +57,9 @@ BSTR RewriteURLW(BSTR urlw) {
     return NULL;
 }
 
-HRESULT InvokeHook(IDispatch *This, DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
-                   DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo,
-                   UINT *puArgErr) {
+static HRESULT InvokeHook(IDispatch *This, DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
+                          DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo,
+                          UINT *puArgErr) {
 
     BSTR newURL = NULL;
 
@@ -83,8 +83,8 @@ HRESULT InvokeHook(IDispatch *This, DISPID dispIdMember, REFIID riid, LCID lcid,
                    puArgErr);
 }
 
-HRESULT STDCALL NavigateHook(IWebBrowser2 *This, BSTR URL, VARIANT *Flags, VARIANT *TargetFrameName,
-                             VARIANT *PostData, VARIANT *Headers) {
+static HRESULT STDCALL NavigateHook(IWebBrowser2 *This, BSTR URL, VARIANT *Flags,
+                                    VARIANT *TargetFrameName, VARIANT *PostData, VARIANT *Headers) {
 
     BSTR newURL = NULL;
 
@@ -104,8 +104,8 @@ HRESULT STDCALL NavigateHook(IWebBrowser2 *This, BSTR URL, VARIANT *Flags, VARIA
     return hResult;
 }
 
-HRESULT STDCALL CoGetClassObjectHook(REFCLSID rclsid, DWORD dwClsContext, LPVOID pvReserved,
-                                     REFIID riid, LPVOID *ppv) {
+static HRESULT STDCALL CoGetClassObjectHook(REFCLSID rclsid, DWORD dwClsContext, LPVOID pvReserved,
+                                            REFIID riid, LPVOID *ppv) {
 
     static void *g_pInvoke = NULL;
 
@@ -148,8 +148,8 @@ HRESULT STDCALL CoGetClassObjectHook(REFCLSID rclsid, DWORD dwClsContext, LPVOID
     return ret;
 }
 
-HRESULT STDCALL CoCreateInstanceHook(REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext,
-                                     REFIID riid, LPVOID *ppv) {
+static HRESULT STDCALL CoCreateInstanceHook(REFCLSID rclsid, LPUNKNOWN pUnkOuter,
+                                            DWORD dwClsContext, REFIID riid, LPVOID *ppv) {
 
     static void *g_pNavigate = NULL;
 

--- a/src/hooks/user32/window.c
+++ b/src/hooks/user32/window.c
@@ -24,10 +24,10 @@ static PFNCREATEWINDOWEXAPROC pCreateWindowExA = NULL;
  * CreateWindowExAHook is a convenience patch that prevents PangYa from
  * creating topmost windows.
  */
-HWND STDCALL CreateWindowExAHook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName,
-                                 DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
-                                 HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,
-                                 LPVOID lpParam) {
+static HWND STDCALL CreateWindowExAHook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName,
+                                        DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+                                        HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,
+                                        LPVOID lpParam) {
     dwExStyle &= (~WS_EX_TOPMOST);
     return pCreateWindowExA(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
                             hWndParent, hMenu, hInstance, lpParam);

--- a/src/hooks/wininet/netredir.c
+++ b/src/hooks/wininet/netredir.c
@@ -69,7 +69,7 @@ typedef struct _internet_ctx {
 
 static internet_ctx g_inet_ctx;
 
-void insertInetCtx(internet_ctx *_ctx) {
+static void insertInetCtx(internet_ctx *_ctx) {
 
     internet_ctx *node = g_inet_ctx._next;
 
@@ -91,10 +91,10 @@ void insertInetCtx(internet_ctx *_ctx) {
     }
 }
 
-void createInetCtx(HINTERNET hOpen, HINTERNET hConnect, LPCSTR lpszServerName,
-                   INTERNET_PORT nServerPort, LPCSTR lpszUserName, LPCSTR lpszPassword,
-                   DWORD dwService, DWORD dwFlags, DWORD_PTR dwContext, HINTERNET hRequest,
-                   HINTERNET hNewConnect) {
+static void createInetCtx(HINTERNET hOpen, HINTERNET hConnect, LPCSTR lpszServerName,
+                          INTERNET_PORT nServerPort, LPCSTR lpszUserName, LPCSTR lpszPassword,
+                          DWORD dwService, DWORD dwFlags, DWORD_PTR dwContext, HINTERNET hRequest,
+                          HINTERNET hNewConnect) {
 
     internet_ctx *ctx = AllocMem(sizeof(internet_ctx));
 
@@ -143,7 +143,7 @@ void createInetCtx(HINTERNET hOpen, HINTERNET hConnect, LPCSTR lpszServerName,
     insertInetCtx(ctx);
 }
 
-void destructInetCtx(internet_ctx *_ctx) {
+static void destructInetCtx(internet_ctx *_ctx) {
 
     if (_ctx == NULL)
         return;
@@ -160,7 +160,7 @@ void destructInetCtx(internet_ctx *_ctx) {
     memset(_ctx, 0, sizeof(internet_ctx));
 }
 
-void removeInetCtx(internet_ctx *_ctx) {
+static void removeInetCtx(internet_ctx *_ctx) {
 
     if (_ctx == NULL || _ctx == &g_inet_ctx)
         return;
@@ -181,7 +181,7 @@ void removeInetCtx(internet_ctx *_ctx) {
     FreeMem((HLOCAL)_ctx);
 }
 
-internet_ctx *findInetCtxByConnect(HINTERNET hConnect) {
+static internet_ctx *findInetCtxByConnect(HINTERNET hConnect) {
 
     if (g_inet_ctx._next == NULL)
         return NULL;
@@ -198,7 +198,7 @@ internet_ctx *findInetCtxByConnect(HINTERNET hConnect) {
     return NULL;
 }
 
-internet_ctx *findInetCtxByRequest(HINTERNET hRequest) {
+static internet_ctx *findInetCtxByRequest(HINTERNET hRequest) {
 
     if (g_inet_ctx._next == NULL)
         return NULL;
@@ -215,7 +215,7 @@ internet_ctx *findInetCtxByRequest(HINTERNET hRequest) {
     return NULL;
 }
 
-int PortLength(INTERNET_PORT _port) {
+static int PortLength(INTERNET_PORT _port) {
 
     if (_port == 80 || _port == 443)
         return 0;
@@ -238,7 +238,7 @@ int PortLength(INTERNET_PORT _port) {
     return length + 7;
 }
 
-int UserNameAndPasswordLength(DWORD _dwUserNameLength, DWORD _dwPasswordLength) {
+static int UserNameAndPasswordLength(DWORD _dwUserNameLength, DWORD _dwPasswordLength) {
 
     if (_dwUserNameLength == 0u && _dwPasswordLength == 0u)
         return 0;
@@ -253,10 +253,9 @@ int UserNameAndPasswordLength(DWORD _dwUserNameLength, DWORD _dwPasswordLength) 
     return length;
 }
 
-HINTERNET STDCALL InternetOpenUrlABypasSelfSignedCertificate(HINTERNET hInternet, LPCSTR lpszUrl,
-                                                             LPCSTR lpszHeaders,
-                                                             DWORD dwHeadersLength, DWORD dwFlags,
-                                                             DWORD_PTR dwContext) {
+static HINTERNET STDCALL InternetOpenUrlABypasSelfSignedCertificate(
+    HINTERNET hInternet, LPCSTR lpszUrl, LPCSTR lpszHeaders, DWORD dwHeadersLength, DWORD dwFlags,
+    DWORD_PTR dwContext) {
 
     URL_COMPONENTSA url_cpsa;
     memset(&url_cpsa, 0, sizeof(URL_COMPONENTSA));
@@ -423,8 +422,9 @@ HINTERNET STDCALL InternetOpenUrlABypasSelfSignedCertificate(HINTERNET hInternet
 /**
  * InternetOpenUrlAHook redirects HTTP calls to localhost.
  */
-HINTERNET STDCALL InternetOpenUrlAHook(HINTERNET hInternet, LPCSTR lpszUrl, LPCSTR lpszHeaders,
-                                       DWORD dwHeadersLength, DWORD dwFlags, DWORD_PTR dwContext) {
+static HINTERNET STDCALL InternetOpenUrlAHook(HINTERNET hInternet, LPCSTR lpszUrl,
+                                              LPCSTR lpszHeaders, DWORD dwHeadersLength,
+                                              DWORD dwFlags, DWORD_PTR dwContext) {
     LPCSTR newURL;
     LPCSTR refURL;
     HINTERNET hResult;
@@ -504,10 +504,10 @@ HINTERNET STDCALL InternetOpenUrlAHook(HINTERNET hInternet, LPCSTR lpszUrl, LPCS
     return hResult;
 }
 
-HINTERNET STDCALL InternetConnectAHook(HINTERNET hInternet, LPCSTR lpszServerName,
-                                       INTERNET_PORT nServerPort, LPCSTR lpszUserName,
-                                       LPCSTR lpszPassword, DWORD dwService, DWORD dwFlags,
-                                       DWORD_PTR dwContext) {
+static HINTERNET STDCALL InternetConnectAHook(HINTERNET hInternet, LPCSTR lpszServerName,
+                                              INTERNET_PORT nServerPort, LPCSTR lpszUserName,
+                                              LPCSTR lpszPassword, DWORD dwService, DWORD dwFlags,
+                                              DWORD_PTR dwContext) {
 
     HINTERNET hConnect = pInternetConnectA(hInternet, lpszServerName, nServerPort, lpszUserName,
                                            lpszPassword, dwService, dwFlags, dwContext);
@@ -519,10 +519,10 @@ HINTERNET STDCALL InternetConnectAHook(HINTERNET hInternet, LPCSTR lpszServerNam
     return hConnect;
 }
 
-HINTERNET STDCALL HttpOpenRequestAHook(HINTERNET hConnect, LPCSTR lpszVerb, LPCSTR lpszObjectName,
-                                       LPCSTR lpszVersion, LPCSTR lpszReferrer,
-                                       LPCSTR *lplpszAcceptTypes, DWORD dwFlags,
-                                       DWORD_PTR dwContext) {
+static HINTERNET STDCALL HttpOpenRequestAHook(HINTERNET hConnect, LPCSTR lpszVerb,
+                                              LPCSTR lpszObjectName, LPCSTR lpszVersion,
+                                              LPCSTR lpszReferrer, LPCSTR *lplpszAcceptTypes,
+                                              DWORD dwFlags, DWORD_PTR dwContext) {
 
     HINTERNET hReq = pHttpOpenRequestA(hConnect, lpszVerb, lpszObjectName, lpszVersion,
                                        lpszReferrer, lplpszAcceptTypes, dwFlags, dwContext);
@@ -685,9 +685,11 @@ HINTERNET STDCALL HttpOpenRequestAHook(HINTERNET hConnect, LPCSTR lpszVerb, LPCS
     return hReq;
 }
 
-BOOL STDCALL HttpSendRequestACertificateInvalidRedirect(HINTERNET hRequest, LPCSTR lpszHeaders,
-                                                        DWORD dwHeadersLength, LPVOID lpOptional,
-                                                        DWORD dwOptionalLength) {
+static BOOL STDCALL HttpSendRequestACertificateInvalidRedirect(HINTERNET hRequest,
+                                                               LPCSTR lpszHeaders,
+                                                               DWORD dwHeadersLength,
+                                                               LPVOID lpOptional,
+                                                               DWORD dwOptionalLength) {
 
     internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
 
@@ -902,8 +904,9 @@ BOOL STDCALL HttpSendRequestACertificateInvalidRedirect(HINTERNET hRequest, LPCS
     return TRUE;
 }
 
-BOOL STDCALL HttpSendRequestAHook(HINTERNET hRequest, LPCSTR lpszHeaders, DWORD dwHeadersLength,
-                                  LPVOID lpOptional, DWORD dwOptionalLength) {
+static BOOL STDCALL HttpSendRequestAHook(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                         DWORD dwHeadersLength, LPVOID lpOptional,
+                                         DWORD dwOptionalLength) {
 
     BOOL bRet = FALSE;
 
@@ -935,9 +938,9 @@ BOOL STDCALL HttpSendRequestAHook(HINTERNET hRequest, LPCSTR lpszHeaders, DWORD 
     return bRet;
 }
 
-BOOL STDCALL HttpSendRequestExAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersIn,
-                                    LPINTERNET_BUFFERSA lpBuffersOut, DWORD dwFlags,
-                                    DWORD_PTR dwContext) {
+static BOOL STDCALL HttpSendRequestExAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersIn,
+                                           LPINTERNET_BUFFERSA lpBuffersOut, DWORD dwFlags,
+                                           DWORD_PTR dwContext) {
 
     BOOL bRet = FALSE;
 
@@ -960,9 +963,9 @@ BOOL STDCALL HttpSendRequestExAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBu
     return bRet;
 }
 
-BOOL STDCALL HttpEndRequestACertificateInvalidRedirect(HINTERNET hRequest,
-                                                       LPINTERNET_BUFFERSA lpBuffersOut,
-                                                       DWORD dwFlags, DWORD_PTR dwContext) {
+static BOOL STDCALL HttpEndRequestACertificateInvalidRedirect(HINTERNET hRequest,
+                                                              LPINTERNET_BUFFERSA lpBuffersOut,
+                                                              DWORD dwFlags, DWORD_PTR dwContext) {
 
     internet_ctx *inet_ctx = findInetCtxByRequest(hRequest);
 
@@ -1202,8 +1205,8 @@ BOOL STDCALL HttpEndRequestACertificateInvalidRedirect(HINTERNET hRequest,
     return TRUE;
 }
 
-BOOL STDCALL HttpEndRequestAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersOut,
-                                 DWORD dwFlags, DWORD_PTR dwContext) {
+static BOOL STDCALL HttpEndRequestAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffersOut,
+                                        DWORD dwFlags, DWORD_PTR dwContext) {
 
     BOOL bRet = FALSE;
 
@@ -1234,8 +1237,8 @@ BOOL STDCALL HttpEndRequestAHook(HINTERNET hRequest, LPINTERNET_BUFFERSA lpBuffe
     return bRet;
 }
 
-BOOL STDCALL HttpAddRequestHeadersAHook(HINTERNET hRequest, LPCSTR lpszHeaders,
-                                        DWORD dwHeadersLength, DWORD dwModifiers) {
+static BOOL STDCALL HttpAddRequestHeadersAHook(HINTERNET hRequest, LPCSTR lpszHeaders,
+                                               DWORD dwHeadersLength, DWORD dwModifiers) {
 
     BOOL bRet = FALSE;
 
@@ -1262,8 +1265,8 @@ BOOL STDCALL HttpAddRequestHeadersAHook(HINTERNET hRequest, LPCSTR lpszHeaders,
     return bRet;
 }
 
-BOOL STDCALL HttpQueryInfoAHook(HINTERNET hRequest, DWORD dwInfoLevel, LPVOID lpBuffer,
-                                LPDWORD lpdwBufferLength, LPDWORD lpdwIndex) {
+static BOOL STDCALL HttpQueryInfoAHook(HINTERNET hRequest, DWORD dwInfoLevel, LPVOID lpBuffer,
+                                       LPDWORD lpdwBufferLength, LPDWORD lpdwIndex) {
 
     BOOL bRet = FALSE;
 
@@ -1278,8 +1281,9 @@ BOOL STDCALL HttpQueryInfoAHook(HINTERNET hRequest, DWORD dwInfoLevel, LPVOID lp
     return bRet;
 }
 
-BOOL STDCALL InternetQueryDataAvailableHook(HINTERNET hFile, LPDWORD lpdwNumberOfBytesAvailable,
-                                            DWORD dwFlags, DWORD_PTR dwContext) {
+static BOOL STDCALL InternetQueryDataAvailableHook(HINTERNET hFile,
+                                                   LPDWORD lpdwNumberOfBytesAvailable,
+                                                   DWORD dwFlags, DWORD_PTR dwContext) {
 
     BOOL bRet = FALSE;
 
@@ -1295,8 +1299,9 @@ BOOL STDCALL InternetQueryDataAvailableHook(HINTERNET hFile, LPDWORD lpdwNumberO
     return bRet;
 }
 
-BOOL STDCALL InternetWriteFileHook(HINTERNET hFile, LPCVOID lpBuffer, DWORD dwNumberOfBytesToWrite,
-                                   LPDWORD lpdwNumberOfBytesWritten) {
+static BOOL STDCALL InternetWriteFileHook(HINTERNET hFile, LPCVOID lpBuffer,
+                                          DWORD dwNumberOfBytesToWrite,
+                                          LPDWORD lpdwNumberOfBytesWritten) {
 
     BOOL bRet = FALSE;
 
@@ -1320,8 +1325,9 @@ BOOL STDCALL InternetWriteFileHook(HINTERNET hFile, LPCVOID lpBuffer, DWORD dwNu
     return bRet;
 }
 
-BOOL STDCALL InternetReadFileHook(HINTERNET hFile, LPVOID lpBuffer, DWORD dwNumberOfBytesToRead,
-                                  LPDWORD lpdwNumberOfBytesRead) {
+static BOOL STDCALL InternetReadFileHook(HINTERNET hFile, LPVOID lpBuffer,
+                                         DWORD dwNumberOfBytesToRead,
+                                         LPDWORD lpdwNumberOfBytesRead) {
 
     BOOL bRet = FALSE;
 
@@ -1336,7 +1342,7 @@ BOOL STDCALL InternetReadFileHook(HINTERNET hFile, LPVOID lpBuffer, DWORD dwNumb
     return bRet;
 }
 
-BOOL STDCALL InternetCloseHandleHook(HINTERNET hInternet) {
+static BOOL STDCALL InternetCloseHandleHook(HINTERNET hInternet) {
 
     internet_ctx *inet_ctx = findInetCtxByConnect(hInternet);
 

--- a/src/json.c
+++ b/src/json.c
@@ -21,7 +21,7 @@
 
 #include "json.h"
 
-BOOL JsonIsSpace(CHAR ch) {
+static BOOL JsonIsSpace(CHAR ch) {
     return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '\v';
 }
 
@@ -55,12 +55,12 @@ LPCSTR JsonTokenName(JSONTOKENTYPE type) {
     return "(unknown)";
 }
 
-void JsonConsumeWhitespace(LPSTR *json) {
+static void JsonConsumeWhitespace(LPSTR *json) {
     while (JsonIsSpace(**json))
         (*json)++;
 }
 
-void JsonConsumeIntegerToken(LPSTR *json, LPJSONTOKEN token) {
+static void JsonConsumeIntegerToken(LPSTR *json, LPJSONTOKEN token) {
     int value = 0;
     int sign = 1;
 
@@ -100,7 +100,7 @@ void JsonConsumeIntegerToken(LPSTR *json, LPJSONTOKEN token) {
     }
 }
 
-void JsonConsumeSymbolToken(LPSTR *json, LPJSONTOKEN token) {
+static void JsonConsumeSymbolToken(LPSTR *json, LPJSONTOKEN token) {
     switch (*(*json)++) {
     case '{':
         token->token_type = JSON_TOK_LBRACE;
@@ -126,7 +126,7 @@ void JsonConsumeSymbolToken(LPSTR *json, LPJSONTOKEN token) {
     }
 }
 
-void JsonConsumeStringToken(LPSTR *json, LPJSONTOKEN token) {
+static void JsonConsumeStringToken(LPSTR *json, LPJSONTOKEN token) {
     LPCSTR strptr;
     LPSTR wptr;
     CHAR ch;
@@ -190,7 +190,7 @@ void JsonConsumeStringToken(LPSTR *json, LPJSONTOKEN token) {
     }
 }
 
-void JsonConsumeKeywordToken(LPSTR *json, LPJSONTOKEN token) {
+static void JsonConsumeKeywordToken(LPSTR *json, LPJSONTOKEN token) {
     if (memcmp(*json, "true", 4) == 0) {
         *json += 4;
         token->token_type = JSON_TOK_TRUE;


### PR DESCRIPTION
There's some missing `static` declarations all over the codebase. Pretty much anything that is not referenced outside of a translation unit should be valid to mark `static`.